### PR TITLE
feature(engine): Dataclass field wrapper to enable OpenAPI description as first parameter

### DIFF
--- a/engine/src/hopeit/dataobjects/__init__.py
+++ b/engine/src/hopeit/dataobjects/__init__.py
@@ -19,6 +19,7 @@ Example:
 """
 import pickle
 import uuid
+import dataclasses
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -29,6 +30,8 @@ from dataclasses_jsonschema import JsonSchemaMixin
 __all__ = ['EventPayload',
            'EventPayloadType',
            'StreamEventParams',
+           'dataclass',
+           'field',
            'dataobject',
            'DataObject',
            'copy_payload',
@@ -189,3 +192,17 @@ def copy_payload(original: Optional[EventPayload]) -> Optional[EventPayload]:
     if hasattr(original, '__data_object__') and original.__data_object__['unsafe']:
         return original
     return _binary_copy(original)
+
+
+def field(description: str, *, default=dataclasses.MISSING, 
+          default_factory=dataclasses.MISSING, init=True, repr=True,
+          hash=None, compare=True, metadata=None):
+    """
+    Wrapper over dataclasses.field adding description for json_schema generation
+    """
+    if metadata is None:
+        metadata = {}
+    metadata['description'] = description
+    return dataclasses.field(default=default, default_factory=default_factory, init=init,
+        repr=repr, hash=hash, compare=compare, metadata=metadata)
+

--- a/engine/test/unit/dataobjects/test_dataobjects.py
+++ b/engine/test/unit/dataobjects/test_dataobjects.py
@@ -2,9 +2,9 @@ import pytest
 import json
 import uuid
 from datetime import datetime, timezone
-from dataclasses import dataclass
+import dataclasses
 
-from hopeit.dataobjects import StreamEventParams, dataobject, copy_payload
+from hopeit.dataobjects import StreamEventParams, dataobject, copy_payload, dataclass, field
 from hopeit.dataobjects.jsonify import Json
 
 
@@ -298,3 +298,18 @@ def test_to_json_invalid_types():
 
     with pytest.raises(ValueError):
         Json.to_json(MockData(id='1', value='ok-value', nested=MockNested(ts="NOT A DATETIME")))  # type: ignore
+
+
+def test_dataclass_field_wrapper():
+    def assert_eq_field(a, b):
+        assert a.metadata == b.metadata
+        assert a.default == b.default
+        assert a.default_factory == b.default_factory
+        assert a.name == b.name
+        assert a.init == b.init
+        assert a.hash == b.hash
+        assert a.repr == b.repr
+    
+    assert_eq_field(field("Foo"), dataclasses.field(metadata={"description": "Foo"}))
+    assert_eq_field(field("Foo", default_factory=dict),
+         dataclasses.field(metadata={"description": "Foo"}, default_factory=dict))


### PR DESCRIPTION
In order to easily document fields for dataclasses in OpenAPI generation:

```
from hopeit.dataobjects import dataobject, dataclass, field

@dataobject
@dataclass
class MyObj:
  name: str = field("Name of the object")

```

will have same effect as using provided dataclasses.field this way:

```
@dataobject
@dataclass
class MyObj:
  name: str = field(metadata={"description": "Name of the object"})
```
