### PR TITLE
fix(engine): create StreamManager when write_stream is present in config

### DIFF
--- a/.github/workflows/hopeit-engine-qa.yml
+++ b/.github/workflows/hopeit-engine-qa.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/engine/src/hopeit/server/engine.py
+++ b/engine/src/hopeit/server/engine.py
@@ -61,7 +61,7 @@ class AppEngine:
             effective_events=self.effective_events)
         streams_present = any(
             True for _, event_info in self.effective_events.items()
-            if event_info.type == EventType.STREAM
+            if (event_info.type == EventType.STREAM) or (event_info.write_stream is not None)
         )
         if streams_present and self.streams_enabled:
             self.stream_manager = await StreamManager(


### PR DESCRIPTION
Problem description:
When no events of types STREAM are present in the app,
but still some events have write_stream specified in config,
StreamManager is not instantiated in engine:

Solution:
StreamManager must be created when event type is STREAM or write_stream is present in app configuration.