### PR TITLE
fix(engine): support POST with empty payload

### DIFF
--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -476,6 +476,9 @@ async def _request_process_payload(
     """
     try:
         payload_str = (await request.read()).decode()
+        print("payload_str", payload_str)
+        if payload_str is None or payload_str == '':
+            return None
         payload = Json.from_json(payload_str, datatype) if datatype else payload_str
         return payload  # type: ignore
     except ValueError as e:

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -476,8 +476,7 @@ async def _request_process_payload(
     """
     try:
         payload_str = (await request.read()).decode()
-        print("payload_str", payload_str)
-        if payload_str is None or payload_str == '':
+        if (payload_str is None) or (payload_str == ''):
             return None
         payload = Json.from_json(payload_str, datatype) if datatype else payload_str
         return payload  # type: ignore

--- a/engine/test/integration/server/test_it_web.py
+++ b/engine/test/integration/server/test_it_web.py
@@ -118,6 +118,22 @@ async def call_post_mock_event(client):
     assert result == '{"value": "ok: ok", "processed": true}'
 
 
+async def call_post_nopayload(client):
+    res: ClientResponse = await client.post(
+        '/api/mock-app/test/mock-post-nopayload',
+        params={'query_arg1': 'ok'},
+        headers={
+            'X-Track-Request-Id': 'test_request_id',
+            'X-Track-Session-Id': 'test_session_id'
+        }
+    )
+    assert res.status == 200
+    assert res.headers.get('X-Track-Session-Id') == 'test_session_id'
+    assert res.headers.get('X-Track-Request-Id') == 'test_request_id'
+    result = (await res.read()).decode()
+    assert result == '{"mock_post_nopayload": "ok: nopayload ok"}'
+
+
 async def call_post_invalid_payload(client):
     res: ClientResponse = await client.post(
         '/api/mock-app/test/mock-event-test',
@@ -421,6 +437,7 @@ def test_all(monkeypatch,
     loop.run_until_complete(call_get_fail_request(test_client))
     loop.run_until_complete(call_get_mock_spawn_event(test_client))
     loop.run_until_complete(call_post_mock_event(test_client))
+    loop.run_until_complete(call_post_nopayload(test_client))
     loop.run_until_complete(call_post_fail_request(test_client))
     loop.run_until_complete(call_get_file_response(test_client))
     loop.run_until_complete(call_get_mock_auth_event(test_client))

--- a/engine/test/mock_app/__init__.py
+++ b/engine/test/mock_app/__init__.py
@@ -60,6 +60,10 @@ def mock_app_config():
                 type=EventType.POST,
                 route='mock-app/test/mock-event-test'
             ),
+            "mock_post_nopayload": EventDescriptor(
+                type=EventType.POST,
+                route='mock-app/test/mock-post-nopayload'
+            ),
             "mock_stream_event": EventDescriptor(
                 type=EventType.STREAM,
                 read_stream=StreamDescriptor(

--- a/engine/test/mock_app/mock_post_nopayload.py
+++ b/engine/test/mock_app/mock_post_nopayload.py
@@ -1,0 +1,11 @@
+from hopeit.app.logger import app_extra_logger
+from hopeit.app.context import EventContext
+
+__steps__ = ['entry_point']
+
+logger, extra = app_extra_logger()
+
+
+def entry_point(payload: None, context: EventContext, query_arg1: str) -> str:
+    logger.info(context, "mock_post_nopayload.entry_point")
+    return f"ok: nopayload {query_arg1}"


### PR DESCRIPTION
Problem description:
When created a post event with payload:None type and no payload specified in API,
call to endpoint was failing trying to convert empty payload from Json.

Solution:
Now empty payloads are mapped to None object and step with payload:None is invoked.
