### PR TITLE
fix(openapi): missing summary

### DIFF
--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -8,7 +8,8 @@
   "paths": {
     "/api/basic-auth/1x0/decode": {
       "get": {
-        "description": "Basic Auth: Decode",
+        "summary": "Basic Auth: Decode",
+        "description": "Returns decoded auth info",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -54,7 +55,8 @@
     },
     "/api/simple-example/1x0/list-somethings": {
       "get": {
-        "description": "Simple Example: List Objects",
+        "summary": "Simple Example: List Objects",
+        "description": "Lists all available Something objects",
         "parameters": [
           {
             "name": "wildcard",
@@ -132,7 +134,8 @@
     },
     "/api/simple-example/1x0/query-something": {
       "get": {
-        "description": "Simple Example: Query Something",
+        "summary": "Simple Example: Query Something",
+        "description": "Loads Something from disk",
         "parameters": [
           {
             "name": "item_id",
@@ -215,7 +218,8 @@
         ]
       },
       "post": {
-        "description": "Simple Example: Query Something Extended",
+        "summary": "Simple Example: Query Something Extended",
+        "description": "Loads Something from disk, update status base on POST body.\nObjects is saved with updated status and history.",
         "parameters": [
           {
             "name": "item_id",
@@ -311,7 +315,8 @@
     },
     "/api/simple-example/1x0/save-something": {
       "post": {
-        "description": "Simple Example: Save Something",
+        "summary": "Simple Example: Save Something",
+        "description": "Creates and saves Something",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -397,7 +402,8 @@
     },
     "/api/simple-example/1x0/streams/something-event": {
       "post": {
-        "description": "Simple Example: Something Event",
+        "summary": "Simple Example: Something Event",
+        "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -474,7 +480,8 @@
     },
     "/api/simple-example/1x0/collector/query-concurrently": {
       "post": {
-        "description": "Simple Example: Query Concurrently",
+        "summary": "Simple Example: Query Concurrently",
+        "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -554,7 +561,8 @@
     },
     "/api/simple-example/1x0/collector/collect-spawn": {
       "post": {
-        "description": "Simple Example: Collect and Spawn",
+        "summary": "Simple Example: Collect and Spawn",
+        "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -640,7 +648,8 @@
     },
     "/api/simple-example/1x0/shuffle/spawn-event": {
       "post": {
-        "description": "Simple Example: Spawn Event",
+        "summary": "Simple Example: Spawn Event",
+        "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -726,7 +735,8 @@
     },
     "/api/simple-example/1x0/shuffle/parallelize-event": {
       "post": {
-        "description": "Simple Example: Parallelize Event",
+        "summary": "Simple Example: Parallelize Event",
+        "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -812,7 +822,8 @@
     },
     "/api/simple-example/1x0/basic-auth/1x0/login": {
       "get": {
-        "description": "Basic Auth: Login",
+        "summary": "Basic Auth: Login",
+        "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -888,7 +899,8 @@
     },
     "/api/simple-example/1x0/basic-auth/1x0/refresh": {
       "get": {
-        "description": "Basic Auth: Refresh",
+        "summary": "Basic Auth: Refresh",
+        "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
         "parameters": [
           {
             "name": "X-Track-Request-Id",
@@ -964,7 +976,8 @@
     },
     "/api/simple-example/1x0/basic-auth/1x0/logout": {
       "get": {
-        "description": "Basic Auth: Logout",
+        "summary": "Basic Auth: Logout",
+        "description": "Invalidates previous refresh cookies.",
         "parameters": [
           {
             "name": "X-Track-Request-Id",

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -19,7 +19,7 @@ Since version 0.1.4 method adds ``summary`` and ``description`` params:
                 description: Optional[str] = None
                 ) -> Callable[..., dict]:
 
-Remove in version 0.2.0 ``title`` parameter, use ``summary`` instead. Stariting this version method will require named args for all parameters:
+From version 0.2.0 'title' will be removed, use ``summary`` instead. Stariting this version method will require named args for all parameters:
 
 .. code:: python3
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -1,0 +1,31 @@
+Deprecations
+============
+
+Module: hopeit.app.api
+______________________
+
+Deprecation warning: 
+Starting hopeit.engine version 0.1.4 event_api method will deprecate ``title`` parameter and will be remove in 0.2.0, use ``summary`` instead.
+
+Since version 0.1.4 method adds ``summary`` and ``description`` params:
+
+.. code:: python3
+
+    def event_api(title: Optional[str] = None,
+                payload: Optional[PayloadDef] = None,
+                query_args: Optional[List[ArgDef]] = None,
+                responses: Optional[Dict[int, PayloadDef]] = None, *,
+                summary: Optional[str] = None,
+                description: Optional[str] = None
+                ) -> Callable[..., dict]:
+
+Remove in version 0.2.0 ``title`` parameter, use ``summary`` instead. Stariting this version method will require named args for all parameters:
+
+.. code:: python3
+
+    def event_api(*, summary: Optional[str] = None,
+                description: Optional[str] = None,
+                payload: Optional[PayloadDef] = None,
+                query_args: Optional[List[ArgDef]] = None,
+                responses: Optional[Dict[int, PayloadDef]] = None              
+                ) -> Callable[..., dict]:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,13 @@ services.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Deprecations:
+
+   deprecations
+
+
+.. toctree::
+   :maxdepth: 2
    :caption: License:
 
    license

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -18,7 +18,7 @@ def libversion(lib):
 
 setuptools.setup(
     name="hopeit.engine",
-    version="0.1.3",
+    version="0.1.4",
     description="Hopeit.py Engine",
     package_dir={
         "": "src"

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -2,6 +2,7 @@
 API Definition helpers for user apps
 """
 import inspect
+import warnings
 from functools import partial
 from typing import Optional, List, Type, Dict, Callable, Union, Tuple, Any, TypeVar
 
@@ -171,7 +172,8 @@ def _event_api(
     return method_spec
 
 
-def event_api(title: Optional[str] = None,
+def event_api(summary: Optional[str] = None,
+              title: Optional[str] = None,
               description: Optional[str] = None,
               payload: Optional[PayloadDef] = None,
               query_args: Optional[List[ArgDef]] = None,
@@ -179,7 +181,8 @@ def event_api(title: Optional[str] = None,
     """
     Provides a convenient way to define Open API specification using Python types for a given app event
     implementation module.
-    :param title: An optional, string summary. If not provided will be taken from module docstring.
+    :param summary: An optional, string summary. If not provided will be taken from module docstring first line.
+    :param title: Deprectated, use summary insted.
     :param description: An optional, string description. If not provided will be taken from module docstring.
     :param payload: Payload schema definition. Could be a single data type, or a tuple with a Type and a description.
     :param query_args: List of query arguments: each argument could be a single string with the arg name (in which case
@@ -205,4 +208,10 @@ def event_api(title: Optional[str] = None,
             }
         )
     """
-    return partial(_event_api, title, description, payload, query_args, responses)
+
+    if title is not None:
+        warnings.warn("title parameter is deprectated, use summary instead", DeprecationWarning)
+        if summary is None:
+            summary = title
+
+    return partial(_event_api, summary, description, payload, query_args, responses)

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -172,15 +172,17 @@ def _event_api(
     return method_spec
 
 
-def event_api(summary: Optional[str] = None,
-              description: Optional[str] = None,
+def event_api(title: Optional[str] = None,
               payload: Optional[PayloadDef] = None,
               query_args: Optional[List[ArgDef]] = None,
               responses: Optional[Dict[int, PayloadDef]] = None, *,
-              title: Optional[str] = None) -> Callable[..., dict]:
+              summary: Optional[str] = None,
+              description: Optional[str] = None
+              ) -> Callable[..., dict]:
     """
     Provides a convenient way to define Open API specification using Python types for a given app event
     implementation module.
+
     :param summary: An optional, string summary. If not provided will be taken from module docstring first line.
     :param description: An optional, string description. If not provided will be taken from module docstring.
     :param payload: Payload schema definition. Could be a single data type, or a tuple with a Type and a description.
@@ -189,7 +191,7 @@ def event_api(summary: Optional[str] = None,
         float, bool), or a tuple of (str, type, str) where last string is argument description.
     :param responses: a dictionary where key HTTP status code and value is the payload definition as describer in
         payload parameter.
-    :param title: Deprectated, use summary insted.
+    :param title: Deprecated, use summary instead.
 
 
     Examples:
@@ -211,7 +213,9 @@ def event_api(summary: Optional[str] = None,
     """
 
     if title is not None:
-        warnings.warn("title parameter is deprectated, use summary instead", DeprecationWarning)
+        warnings.warn(
+            "title parameter is deprecated since 0.1.4 and will be removed in version 0.2.0, use summary instead",
+            DeprecationWarning)
         if summary is None:
             summary = title
 

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -106,7 +106,7 @@ def _method_summary(module: str, summary: Optional[str] = None) -> str:
     return ""
 
 
-def _method_description(module, summary: Optional[str] = None, description: Optional[str] = None) -> str:
+def _method_description(module: str, description: Optional[str] = None, summary: Optional[str] = None) -> str:
     if description is not None:
         return description
     doc_str = inspect.getdoc(module)
@@ -145,7 +145,7 @@ def _event_api(
         })
     method_spec: Dict[str, Any] = {
         "summary": _method_summary(module, summary),
-        "description": _method_description(module, summary, description),
+        "description": _method_description(module, description, summary),
         "parameters": parameters
     }
     if payload is not None:

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -173,16 +173,15 @@ def _event_api(
 
 
 def event_api(summary: Optional[str] = None,
-              title: Optional[str] = None,
               description: Optional[str] = None,
               payload: Optional[PayloadDef] = None,
               query_args: Optional[List[ArgDef]] = None,
-              responses: Optional[Dict[int, PayloadDef]] = None) -> Callable[..., dict]:
+              responses: Optional[Dict[int, PayloadDef]] = None, *,
+              title: Optional[str] = None) -> Callable[..., dict]:
     """
     Provides a convenient way to define Open API specification using Python types for a given app event
     implementation module.
     :param summary: An optional, string summary. If not provided will be taken from module docstring first line.
-    :param title: Deprectated, use summary insted.
     :param description: An optional, string description. If not provided will be taken from module docstring.
     :param payload: Payload schema definition. Could be a single data type, or a tuple with a Type and a description.
     :param query_args: List of query arguments: each argument could be a single string with the arg name (in which case
@@ -190,6 +189,8 @@ def event_api(summary: Optional[str] = None,
         float, bool), or a tuple of (str, type, str) where last string is argument description.
     :param responses: a dictionary where key HTTP status code and value is the payload definition as describer in
         payload parameter.
+    :param title: Deprectated, use summary insted.
+
 
     Examples:
 

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -6,6 +6,7 @@ import warnings
 from functools import partial
 from typing import Optional, List, Type, Dict, Callable, Union, Tuple, Any, TypeVar
 
+import re
 import typing_inspect  # type: ignore
 
 from hopeit.app.config import AppConfig, AppDescriptor
@@ -111,7 +112,7 @@ def _method_description(module: str, description: Optional[str] = None, summary:
         return description
     doc_str = inspect.getdoc(module)
     if doc_str is not None and doc_str.count('\n') > 1:
-        return doc_str.split("\n", 2)[2]
+        return re.sub(r"^\W+", "", doc_str.split("\n", 1)[1])
     return _method_summary(module, summary)
 
 

--- a/engine/test/mock_app/__init__.py
+++ b/engine/test/mock_app/__init__.py
@@ -246,6 +246,7 @@ def mock_api_spec():
         "paths": {
             "/api/mock-app-api/test/mock-app-api": {
                 "get": {
+                    "summary": "Test app api",
                     "description": "Test app api",
                     "parameters": [
                         {
@@ -303,7 +304,8 @@ def mock_api_spec():
                     ]
                 },
                 "post": {
-                    "description": "Test app api part 2",
+                    "summary": "Test app api part 2",
+                    "description": "Description Test app api part 2",
                     "parameters": [
                         {
                             "name": "arg1",
@@ -381,7 +383,8 @@ def mock_api_spec():
                 }
             }, '/api/mock-app-api/test/mock-app-api-get-list': {
                 'get': {
-                    'description': 'Test app api list',
+                    'summary': 'Test app api list',
+                    'description': 'Description of Test app api list',
                     'parameters': [{
                         'description': 'Argument 1',
                         'in': 'query',

--- a/engine/test/mock_app/mock_app_api_get.py
+++ b/engine/test/mock_app/mock_app_api_get.py
@@ -12,6 +12,7 @@ logger, extra = app_extra_logger()
 __steps__ = ['entry_point']
 
 __api__ = {
+    "summary": "Test app api",
     "description": "Test app api",
     "parameters": [
         {

--- a/engine/test/mock_app/mock_app_api_get_list.py
+++ b/engine/test/mock_app/mock_app_api_get_list.py
@@ -1,5 +1,7 @@
 """
 NO TITLE HERE, Title in __api__
+----------------
+Description of Test app api list
 """
 from typing import Optional, List
 

--- a/engine/test/mock_app/mock_app_api_get_list.py
+++ b/engine/test/mock_app/mock_app_api_get_list.py
@@ -1,6 +1,6 @@
 """
 NO TITLE HERE, Title in __api__
-----------------
+
 Description of Test app api list
 """
 from typing import Optional, List

--- a/engine/test/mock_app/mock_app_api_post.py
+++ b/engine/test/mock_app/mock_app_api_post.py
@@ -12,6 +12,7 @@ from mock_app import MockData
 logger, extra = app_extra_logger()
 
 __api__ = event_api(
+    description="Description Test app api part 2",
     payload=(MockData, "MockData payload"),
     query_args=[('arg1', str, "Argument 1")],
     responses={

--- a/engine/test/mock_app/mock_app_api_title.py
+++ b/engine/test/mock_app/mock_app_api_title.py
@@ -1,0 +1,27 @@
+"""
+Test app api part 2, overwrite by title
+"""
+from hopeit.app.api import event_api
+from hopeit.app.logger import app_extra_logger
+from hopeit.app.context import EventContext
+
+__steps__ = ['entry_point']
+
+from mock_app import MockData
+
+logger, extra = app_extra_logger()
+
+__api__ = event_api(
+    title="Test app api part 2",
+    description="Description Test app api part 2",
+    payload=(MockData, "MockData payload"),
+    query_args=[('arg1', str, "Argument 1")],
+    responses={
+        200: int
+    }
+)
+
+
+def entry_point(payload: MockData, context: EventContext, arg1: str) -> int:
+    logger.info(context, "mock_app_api_post.entry_point")
+    return len(payload.value) + len(arg1)

--- a/engine/test/unit/app/test_app_api.py
+++ b/engine/test/unit/app/test_app_api.py
@@ -5,7 +5,7 @@ import pytest
 import hopeit.app.api as api
 from hopeit.app.config import EventType
 from hopeit.server.api import APIError
-from mock_app import mock_app_api_get, MockData, mock_app_api_post, mock_app_api_get_list
+from mock_app import mock_app_api_get, MockData, mock_app_api_post, mock_app_api_get_list, mock_app_api_title
 from mock_app import mock_api_app_config, mock_api_spec  # noqa: F401
 
 
@@ -55,6 +55,31 @@ def test_event_api_post(monkeypatch, mock_api_spec, mock_api_app_config):  # noq
         query_args=['arg1'],
         responses={200: int}
     )(mock_app_api_post, app_config=mock_api_app_config, event_name='mock-app-api-post', plugin=None)
+    assert spec['summary'] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['summary']
+    assert spec['description'] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['description']
+    assert spec['parameters'][0] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['parameters'][0]
+    assert spec['requestBody'] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['requestBody']
+    assert spec['responses'] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['responses']
+
+
+def test_event_api_title(monkeypatch, mock_api_spec, mock_api_app_config):  # noqa: F811
+    monkeypatch.setattr(api, 'spec', mock_api_spec)
+    mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['parameters'][0]['description'] = \
+        'arg1'
+    mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['requestBody']['description'] = \
+        'MockData'
+    spec = api.event_api(
+        title="Test app api part 2",
+        description="Description Test app api part 2",
+        payload=MockData,
+        query_args=['arg1'],
+        responses={200: int}
+    )(mock_app_api_title, app_config=mock_api_app_config, event_name='mock-app-api-post', plugin=None)
     assert spec['summary'] == \
         mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['summary']
     assert spec['description'] == \

--- a/engine/test/unit/app/test_app_api.py
+++ b/engine/test/unit/app/test_app_api.py
@@ -31,6 +31,7 @@ def test_api_from_config_missing(monkeypatch, mock_api_spec, mock_api_app_config
 def test_event_api(monkeypatch, mock_api_spec, mock_api_app_config):  # noqa: F811
     monkeypatch.setattr(api, 'spec', mock_api_spec)
     spec = api.event_api(
+        description="Test app api",
         payload=(str, "Payload"),
         query_args=[('arg1', Optional[int], "Argument 1")],
         responses={200: (MockData, "MockData result")}

--- a/engine/test/unit/app/test_app_api.py
+++ b/engine/test/unit/app/test_app_api.py
@@ -6,7 +6,7 @@ import hopeit.app.api as api
 from hopeit.app.config import EventType
 from hopeit.server.api import APIError
 from mock_app import mock_app_api_get, MockData, mock_app_api_post, mock_app_api_get_list
-from mock_app import mock_api_app_config, mock_api_spec  # type: ignore  # noqa: F401
+from mock_app import mock_api_app_config, mock_api_spec  # noqa: F401
 
 
 def test_api_from_config(monkeypatch, mock_api_spec, mock_api_app_config):  # noqa: F811
@@ -50,10 +50,13 @@ def test_event_api_post(monkeypatch, mock_api_spec, mock_api_app_config):  # noq
     mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['requestBody']['description'] = \
         'MockData'
     spec = api.event_api(
+        description="Description Test app api part 2",
         payload=MockData,
         query_args=['arg1'],
         responses={200: int}
     )(mock_app_api_post, app_config=mock_api_app_config, event_name='mock-app-api-post', plugin=None)
+    assert spec['summary'] == \
+        mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['summary']
     assert spec['description'] == \
         mock_api_spec['paths']['/api/mock-app-api/test/mock-app-api']['post']['description']
     assert spec['parameters'][0] == \


### PR DESCRIPTION
**PROBLEM:**
* In OpenAPI specs generation `summary` property is missing and there is no api to add it.
* `event_api` method use `title` parameter to set description property to the OpenAPI generated spec, this is confusing.  

**PROPOSAL:**
* Add to `event_api` method ``summary`` instead of ``title``, and `description` parameters and warn of deprecation in the usage of ``title`` starting on 0.1.4 hopeit.engine version, and removal on hopeit.engine 0.2.0
* if event_api don't provides method or description or any, try from module docstring.

**IMPLEMENTATION:**
Note that always `event_api` have precedence over docstring.

* for a given module with `summary` and `description` defined in `event_api` : 

```
"""
get-something

This method return something Object.
This is a second description line 
"""

__api__ = event_api(summary="get something", description="Return something", ...)
```
will produce: 

```
{
summary:  get something,
description: "Return something",
...
}
```
* if not provides some or any of the `summary` or `description` parameters, the OpeanAPI processor will try from module docstring: 

```
"""
get-something

This method return something Object
This is a second description line 
"""

__api__ = event_api(...)
```
will produce:

```
{
summary:  get-something,
description: "This method return something Object \n This is a second description line",
...
}
```

*NOTE ON `docstring` PROCESSING:*
`summary` will be taken from the first line of docstring.
`description` will be taken from the second line and on of the docstring. If the resulting description has a empty first line, it will be removed.

Remember `event_api` definitions always have precedence over docstring