### PR TITLE
fix(engine): CI Action for package publishing on PyPI

### DIFF
--- a/.github/workflows/hopeit-engine-pypi-publishing.yml
+++ b/.github/workflows/hopeit-engine-pypi-publishing.yml
@@ -19,8 +19,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-      env: 
-        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     - name: Install dependencies
       run: |
         make locked-deps
@@ -28,5 +26,7 @@ jobs:
       run: |
         make dist
     - name: Publish hopeit.engine on PyPI
+      env: 
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         make pypi

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ If an external request triggers a process that requires background tasks to run,
 
 ## Current status and roadmap
 
+- **FEBRUARY 2021**: hopeit.engine version 0.1.5 is released on PyPI, enjoy!
+
 - **JULY 2020**: hopeit.engine version 0.1.0 is released as Open Source in github!
     
 - We are mainly working in improving documentation and tutorials.


### PR DESCRIPTION
Related to #27 
- [x] move `env` to publishing job in CI Action for package publishing on PyPI workflow
- [x] update README