### PR TITLE
fix(engine): swagger validator unhandled error with optional/nullable fields

### DIFF
--- a/engine/requirements.lock
+++ b/engine/requirements.lock
@@ -1,7 +1,7 @@
 aiofiles==0.6.0
 aiohttp==3.7.4.post0
 aiohttp-cors==0.7.0
-aiohttp-swagger3==0.5.3
+aiohttp-swagger3==0.5.4
 aiojobs==0.3.0
 aioredis==1.3.1
 async-timeout==3.0.1

--- a/engine/requirements.lock
+++ b/engine/requirements.lock
@@ -13,8 +13,8 @@ click==7.1.2
 cryptography==3.3.2
 dataclasses-jsonschema==2.14.1
 deepdiff==5.2.3
-fastjsonschema==2.14.5
-hiredis==1.1.0
+fastjsonschema==2.15.0
+hiredis==2.0.0
 idna==3.1
 jsonschema==3.2.0
 lz4==3.1.3
@@ -25,7 +25,7 @@ pycparser==2.20
 PyJWT==1.7.1
 pyrsistent==0.17.3
 python-dateutil==2.8.1
-PyYAML==5.3.1
+PyYAML==5.4.1
 six==1.15.0
 strict-rfc3339==0.7
 stringcase==1.2.0

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 aiohttp-cors
-aiohttp-swagger3
+aiohttp-swagger3==0.5.4
 aiojobs
 aiofiles
 dataclasses-jsonschema[fast-validation]

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -3,4 +3,4 @@ Engine version constants.
 Increment on release
 """
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.2.0rc1"
+ENGINE_VERSION = "0.2.0rc2"


### PR DESCRIPTION
Custom validator implemented for Multipart uploads on top of aiohttop_swagger3, threw unhandled TypeError on the presence of Nullable or Optional missing fields.

This PR solves the issue by:
- [x] Ported code from aiohttp_swagger3 0.5.4 that handles this conditions (bad `return None` in previous version)
- [x] Customized is_missing logic to handle json field in multipart/form requests
- [x] Pinned aiohttp_swagger3 version to 0.5.4 to prevent logic changes to validator 

After merge will release 0.2.0rc2
 