### PR TITLE
fix(engine): Split generic Stream Manager from Redis specifics

### DIFF
--- a/docs/source/apidocs/hopeit.rst
+++ b/docs/source/apidocs/hopeit.rst
@@ -11,5 +11,6 @@ Subpackages
    hopeit.cli
    hopeit.dataobjects
    hopeit.server
+   hopeit.streams
    hopeit.testing
    hopeit.toolkit

--- a/docs/source/apidocs/hopeit.server.rst
+++ b/docs/source/apidocs/hopeit.server.rst
@@ -88,12 +88,6 @@ Submodules
    :show-inheritance:
 
 
-.. automodule:: hopeit.server.streams
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
 .. automodule:: hopeit.server.version
    :members:
    :undoc-members:

--- a/docs/source/apidocs/hopeit.streams.rst
+++ b/docs/source/apidocs/hopeit.streams.rst
@@ -1,0 +1,16 @@
+hopeit.streams package
+======================
+
+.. automodule:: hopeit.streams
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+
+.. automodule:: hopeit.streams.redis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,9 +2,10 @@ Release Notes
 =============
 
 
-Version 0.2.1
+Version 0.2.2
 _____________
 - Remove unnecessary decode when parsing payload on web module 
+- Split generic Stream Manager from Redis specifics
 
 
 Version 0.2.0

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
         "hopeit.cli",
         "hopeit.dataobjects",
         "hopeit.server",
+        "hopeit.streams",
         "hopeit.testing",
         "hopeit.toolkit", 
         "hopeit.toolkit.storage"

--- a/engine/src/hopeit/server/__init__.py
+++ b/engine/src/hopeit/server/__init__.py
@@ -26,6 +26,5 @@ __all__ = ['config',
            'metrics',
            'names',
            'steps',
-           'streams',
            'web',
            'api']

--- a/engine/src/hopeit/server/engine.py
+++ b/engine/src/hopeit/server/engine.py
@@ -16,7 +16,8 @@ from hopeit.app.context import EventContext, PostprocessHook, PreprocessHook
 from hopeit.dataobjects import EventPayload
 from hopeit.server.config import ServerConfig
 from hopeit.server.events import EventHandler
-from hopeit.server.streams import StreamManager, stream_auth_info, StreamEvent, StreamOSError
+from hopeit.streams import stream_auth_info, StreamEvent, StreamOSError, StreamManager
+from hopeit.streams.redis import RedisStreamManager
 from hopeit.server.logger import engine_logger, extra_logger, combined
 from hopeit.server.metrics import metrics, stream_metrics, StreamStats
 
@@ -64,7 +65,7 @@ class AppEngine:
             if (event_info.type == EventType.STREAM) or (event_info.write_stream is not None)
         )
         if streams_present and self.streams_enabled:
-            self.stream_manager = await StreamManager(
+            self.stream_manager = await RedisStreamManager(
                 address=streams_connection_str).connect()
         return self
 

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -3,4 +3,4 @@ Engine version constants.
 Increment on release
 """
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.2.1"
+ENGINE_VERSION = "0.2.2"

--- a/engine/src/hopeit/streams/__init__.py
+++ b/engine/src/hopeit/streams/__init__.py
@@ -2,22 +2,18 @@
 Streams module. Handles reading and writing to streams.
 Backed by Redis Streams
 """
-import asyncio
+from abc import ABC
 import os
 import socket
 import json
 import base64
-import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Union
 from dataclasses import dataclass
 
-import aioredis  # type: ignore
-from aioredis import RedisError
-
 from hopeit.app.config import Compression, Serialization
 from hopeit.dataobjects import EventPayload
-from hopeit.server.serialization import serialize, deserialize
+from hopeit.server.serialization import serialize
 from hopeit.server.config import AuthType
 from hopeit.server.logger import engine_logger, extra_logger
 
@@ -49,50 +45,22 @@ def stream_auth_info(stream_event: StreamEvent):
     }
 
 
-class StreamManager:
+class StreamManager(ABC):
     """
-    Manages streams of a Hopeit App
+    Base class to imeplement stream management of a Hopeit App
     """
-
-    def __init__(self, *, address: str):
-        """
-        Creates an StreamManager instance backed by redis connection
-        specified in `address`.
-
-        After creation, `connect()` must be called to create connection pools.
-        """
-        self.address = address
-        self.consumer_id = self._consumer_id()
-        self._write_pool: aioredis.Redis = None
-        self._read_pool: aioredis.Redis = None
-
     async def connect(self):
         """
         Connects to Redis using two connection pools, one to handle
         writing to stream and one for reading.
         """
-        logger.info(__name__, f"Connecting address={self.address}...")
-        try:
-            self._write_pool = await aioredis.create_redis_pool(self.address)
-            self._read_pool = await aioredis.create_redis_pool(self.address)
-            return self
-        except (OSError, RedisError) as e:
-            logger.error(__name__, e)
-            raise StreamOSError(e) from e
+        raise NotImplementedError()
 
     async def close(self):
         """
         Close connections to Redis
         """
-
-        async def _close(pool) -> None:
-            if pool:
-                pool.close()
-                await pool.wait_closed()
-            return None
-
-        self._read_pool = await _close(self._read_pool)
-        self._write_pool = await _close(self._write_pool)
+        raise NotImplementedError()
 
     async def write_stream(self, *,
                            stream_name: str,
@@ -114,12 +82,7 @@ class StreamManager:
             default 0 will not send max_len to Redis.
         :return: number of successful written messages
         """
-        event_fields = self._fields(payload, track_ids, auth_info, compression, serialization)
-        ok = await self._write_pool.xadd(
-            stream=stream_name, fields=event_fields,
-            max_len=target_max_len if target_max_len > 0 else None,
-            exact_len=False)
-        return ok
+        raise NotImplementedError()
 
     async def ensure_consumer_group(self, *,
                                     stream_name: str,
@@ -134,45 +97,7 @@ class StreamManager:
         :param stream_name: str, stream name or key used by Redis
         :param consumer_group: str, consumer group passed to Redis
         """
-        try:
-            await self._read_pool.xgroup_create(
-                stream_name,
-                consumer_group,
-                latest_id='0',
-                mkstream=True
-            )
-        except aioredis.errors.BusyGroupError:
-            logger.info(__name__,
-                        "Consumer_group already exists " +
-                        f"read_stream={stream_name} consumer_group={consumer_group}")
-
-    def _decode_message(self, msg: List[Union[bytes, Dict[bytes, bytes]]],
-                        datatype: type, consumer_group: str,
-                        track_headers: List[str], read_ts: str):
-        assert isinstance(msg[0], bytes) and isinstance(msg[1], bytes) and isinstance(msg[2], dict), \
-            "Invalid message format. Expected `[bytes, bytes, Dict[bytes, bytes]]`"
-        compression = Compression(msg[2][b'comp'].decode())
-        serialization = Serialization(msg[2][b'ser'].decode())
-        return StreamEvent(
-            msg_internal_id=msg[1],
-            payload=deserialize(
-                msg[2][b'payload'], serialization, compression, datatype),  # type: ignore
-            track_ids={
-                'stream.name': msg[0].decode(),
-                'stream.msg_id': msg[1].decode(),
-                'stream.consumer_group': consumer_group,
-                'stream.submit_ts': msg[2][b'submit_ts'].decode(),
-                'stream.event_ts': msg[2][b'event_ts'].decode(),
-                'stream.event_id': msg[2][b'id'].decode(),
-                'stream.read_ts': read_ts,
-                **{
-                    k: (msg[2].get(k.encode()) or b'').decode()
-                    for k in track_headers
-                },
-                'track.operation_id': str(uuid.uuid4()),
-            },
-            auth_info=json.loads(base64.b64decode(msg[2].get(b'auth_info', b'{}')))
-        )
+        raise NotImplementedError()
 
     async def read_stream(self, *,
                           stream_name: str,
@@ -205,41 +130,7 @@ class StreamManager:
         :param compression: Compression, supported compression algorithm from enum
         :return: yields Tuples of message id (bytes) and deserialized DataObject
         """
-        try:
-            batch = await self._read_pool.xread_group(
-                consumer_group,
-                self.consumer_id,
-                streams=[stream_name],
-                latest_ids=[offset],
-                count=batch_size,
-                timeout=timeout
-            )
-
-            msg_count = len(batch)
-
-            if msg_count != 0:
-                logger.debug(__name__, "Received batch",
-                             extra=extra(prefix='stream.', name=stream_name, consumer_group=consumer_group,
-                                         batch_size=msg_count, head=batch[0][1], tail=batch[-1][1]))
-                stream_events: List[Union[StreamEvent, Exception]] = []
-                for msg in batch:
-                    read_ts = datetime.now().astimezone(tz=timezone.utc).isoformat()
-                    msg_type = msg[2][b'type'].decode()
-                    datatype = datatypes.get(msg_type)
-                    if datatype is None:
-                        err_msg = \
-                            f"Cannot read msg_id={msg[1].decode()}: msg_type={msg_type} is not any of {datatypes}"
-                        stream_events.append(TypeError(err_msg))
-                    else:
-                        stream_events.append(
-                            self._decode_message(msg, datatype, consumer_group, track_headers, read_ts))
-                return stream_events
-
-            #  Wait some time if no messages to prevent race condition in connection pool
-            await asyncio.sleep(batch_interval / 1000.0)
-            return []
-        except (OSError, RedisError) as e:
-            raise StreamOSError(e) from e
+        raise NotImplementedError()
 
     async def ack_read_stream(self, *,
                               stream_name: str,
@@ -256,9 +147,7 @@ class StreamManager:
         :param consumer_group: str, consumer group registered with Redis
         :param stream_event: StreamEvent, as provided by `read_stream(...)` method
         """
-        ack = await self._read_pool.xack(stream_name, consumer_group, stream_event.msg_internal_id)
-        assert ack == 1
-        return ack
+        raise NotImplementedError()
 
     @staticmethod
     def as_data_event(payload: EventPayload) -> EventPayload:
@@ -311,7 +200,7 @@ class StreamManager:
 
     def _consumer_id(self) -> str:
         """
-        Constructs a consumer if for this instance
+        Constructs a consumer id for this instance
 
         :return: str, concatenating current UTC ISO datetime, host name, process id
             and this StreamManager instance id

--- a/engine/src/hopeit/streams/redis.py
+++ b/engine/src/hopeit/streams/redis.py
@@ -1,0 +1,234 @@
+"""
+Streams module. Handles reading and writing to streams.
+Backed by Redis Streams
+"""
+import asyncio
+import json
+import base64
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, List, Any, Union
+
+import aioredis  # type: ignore
+from aioredis import RedisError
+
+from hopeit.app.config import Compression, Serialization
+from hopeit.dataobjects import EventPayload
+from hopeit.server.serialization import deserialize
+from hopeit.server.logger import engine_logger, extra_logger
+from hopeit.streams import StreamManager, StreamEvent, StreamOSError
+
+logger = engine_logger()
+extra = extra_logger()
+
+
+class RedisStreamManager(StreamManager):
+    """
+    Manages streams of a Hopeit App
+    """
+
+    def __init__(self, *, address: str):
+        """
+        Creates an StreamManager instance backed by redis connection
+        specified in `address`.
+
+        After creation, `connect()` must be called to create connection pools.
+        """
+        self.address = address
+        self.consumer_id = self._consumer_id()
+        self._write_pool: aioredis.Redis = None
+        self._read_pool: aioredis.Redis = None
+
+    async def connect(self):
+        """
+        Connects to Redis using two connection pools, one to handle
+        writing to stream and one for reading.
+        """
+        logger.info(__name__, f"Connecting address={self.address}...")
+        try:
+            self._write_pool = await aioredis.create_redis_pool(self.address)
+            self._read_pool = await aioredis.create_redis_pool(self.address)
+            return self
+        except (OSError, RedisError) as e:
+            logger.error(__name__, e)
+            raise StreamOSError(e) from e
+
+    async def close(self):
+        """
+        Close connections to Redis
+        """
+
+        async def _close(pool) -> None:
+            if pool:
+                pool.close()
+                await pool.wait_closed()
+            return None
+
+        self._read_pool = await _close(self._read_pool)
+        self._write_pool = await _close(self._write_pool)
+
+    async def write_stream(self, *,
+                           stream_name: str,
+                           payload: EventPayload,
+                           track_ids: Dict[str, str],
+                           auth_info: Dict[str, Any],
+                           compression: Compression,
+                           serialization: Serialization,
+                           target_max_len: int = 0) -> int:
+        """
+        Writes event to a Redis stream using XADD
+
+        :param stream_name: stream name or key used by Redis
+        :param payload: EventPayload, a special type of dataclass object decorated with `@dataobject`
+        :param track_ids: dict with key and id values to track in stream event
+        :param auth_info: dict with auth info to be tracked as part of stream event
+        :param compression: Compression, supported compression algorithm from enum
+        :param target_max_len: int, max_len to indicate approx. target collection size to Redis,
+            default 0 will not send max_len to Redis.
+        :return: number of successful written messages
+        """
+        event_fields = self._fields(payload, track_ids, auth_info, compression, serialization)
+        ok = await self._write_pool.xadd(
+            stream=stream_name, fields=event_fields,
+            max_len=target_max_len if target_max_len > 0 else None,
+            exact_len=False)
+        return ok
+
+    async def ensure_consumer_group(self, *,
+                                    stream_name: str,
+                                    consumer_group: str):
+        """
+        Ensures a consumer_group exists for a given stream.
+        If group does not exists, XGROUP_CREATE will be executed in Redis and consumer group
+        created to consume event from beginning of stream (from id=0)
+        If group already exists a message will be logged and no action performed.
+        If stream does not exists and empty stream will be created.
+
+        :param stream_name: str, stream name or key used by Redis
+        :param consumer_group: str, consumer group passed to Redis
+        """
+        try:
+            await self._read_pool.xgroup_create(
+                stream_name,
+                consumer_group,
+                latest_id='0',
+                mkstream=True
+            )
+        except aioredis.errors.BusyGroupError:
+            logger.info(__name__,
+                        "Consumer_group already exists " +
+                        f"read_stream={stream_name} consumer_group={consumer_group}")
+
+    def _decode_message(self, msg: List[Union[bytes, Dict[bytes, bytes]]],
+                        datatype: type, consumer_group: str,
+                        track_headers: List[str], read_ts: str):
+        assert isinstance(msg[0], bytes) and isinstance(msg[1], bytes) and isinstance(msg[2], dict), \
+            "Invalid message format. Expected `[bytes, bytes, Dict[bytes, bytes]]`"
+        compression = Compression(msg[2][b'comp'].decode())
+        serialization = Serialization(msg[2][b'ser'].decode())
+        return StreamEvent(
+            msg_internal_id=msg[1],
+            payload=deserialize(
+                msg[2][b'payload'], serialization, compression, datatype),  # type: ignore
+            track_ids={
+                'stream.name': msg[0].decode(),
+                'stream.msg_id': msg[1].decode(),
+                'stream.consumer_group': consumer_group,
+                'stream.submit_ts': msg[2][b'submit_ts'].decode(),
+                'stream.event_ts': msg[2][b'event_ts'].decode(),
+                'stream.event_id': msg[2][b'id'].decode(),
+                'stream.read_ts': read_ts,
+                **{
+                    k: (msg[2].get(k.encode()) or b'').decode()
+                    for k in track_headers
+                },
+                'track.operation_id': str(uuid.uuid4()),
+            },
+            auth_info=json.loads(base64.b64decode(msg[2].get(b'auth_info', b'{}')))
+        )
+
+    async def read_stream(self, *,
+                          stream_name: str,
+                          consumer_group: str,
+                          datatypes: Dict[str, type],
+                          track_headers: List[str],
+                          offset: str,
+                          batch_size: int,
+                          timeout: int,
+                          batch_interval: int) -> List[Union[StreamEvent, Exception]]:
+        """
+        Attempts reading streams using a consumer group,
+        blocks for `timeout` seconds
+        and yields asynchronously the deserialized objects gotten from the stream.
+        In case timeout is reached, nothing is yielded
+        and read_stream must be called again,
+        usually in an infinite loop while app is running.
+
+        :param stream_name: str, stream name or key used by Redis
+        :param consumer_group: str, consumer group registered in Redis
+        :param datatypes: Dict[str, type] supported datatypes name: type to be extracted from stream.
+            Types need to support json deserialization using `@dataobject` annotation
+        :param track_headers: list of headers/id fields to extract from message if available
+        :param offset: str, last msg id consumed to resume from. Use'>' to consume unconsumed events,
+            or '$' to consume upcoming events
+        :param batch_size: max number of messages to process on each iteration
+        :param timeout: time to block waiting for messages, in milliseconds
+        :param batch_interval: int, time to sleep between requests to connection pool in case no
+            messages are returned. In milliseconds. Used to prevent blocking the pool.
+        :param compression: Compression, supported compression algorithm from enum
+        :return: yields Tuples of message id (bytes) and deserialized DataObject
+        """
+        try:
+            batch = await self._read_pool.xread_group(
+                consumer_group,
+                self.consumer_id,
+                streams=[stream_name],
+                latest_ids=[offset],
+                count=batch_size,
+                timeout=timeout
+            )
+
+            msg_count = len(batch)
+
+            if msg_count != 0:
+                logger.debug(__name__, "Received batch",
+                             extra=extra(prefix='stream.', name=stream_name, consumer_group=consumer_group,
+                                         batch_size=msg_count, head=batch[0][1], tail=batch[-1][1]))
+                stream_events: List[Union[StreamEvent, Exception]] = []
+                for msg in batch:
+                    read_ts = datetime.now().astimezone(tz=timezone.utc).isoformat()
+                    msg_type = msg[2][b'type'].decode()
+                    datatype = datatypes.get(msg_type)
+                    if datatype is None:
+                        err_msg = \
+                            f"Cannot read msg_id={msg[1].decode()}: msg_type={msg_type} is not any of {datatypes}"
+                        stream_events.append(TypeError(err_msg))
+                    else:
+                        stream_events.append(
+                            self._decode_message(msg, datatype, consumer_group, track_headers, read_ts))
+                return stream_events
+
+            #  Wait some time if no messages to prevent race condition in connection pool
+            await asyncio.sleep(batch_interval / 1000.0)
+            return []
+        except (OSError, RedisError) as e:
+            raise StreamOSError(e) from e
+
+    async def ack_read_stream(self, *,
+                              stream_name: str,
+                              consumer_group: str,
+                              stream_event: StreamEvent):
+        """
+        Acknowledges a read message to Redis streams.
+        Acknowledged messages are removed from a pending list by Redis.
+        This method should be called for every message that is properly
+        received and processed with no errors.
+        With this mechanism, messages not acknowledged can be retried.
+
+        :param stream_name: str, stream name or key used by Redis
+        :param consumer_group: str, consumer group registered with Redis
+        :param stream_event: StreamEvent, as provided by `read_stream(...)` method
+        """
+        ack = await self._read_pool.xack(stream_name, consumer_group, stream_event.msg_internal_id)
+        assert ack == 1
+        return ack

--- a/engine/test/integration/server/test_it_web.py
+++ b/engine/test/integration/server/test_it_web.py
@@ -12,7 +12,7 @@ from pytest_aiohttp import aiohttp_server, aiohttp_client  # type: ignore  # noq
 import hopeit.server.web
 from hopeit.server import api
 from hopeit.server.web import start_server, stop_server, start_app
-from hopeit.server.streams import StreamManager
+from hopeit.streams.redis import RedisStreamManager
 
 from mock_engine import MockStreamManager, MockEventHandler
 from mock_app import MockResult, mock_app_config  # type: ignore  # noqa: F401
@@ -488,14 +488,14 @@ def _setup(monkeypatch,
            aiohttp_client,  # noqa: F811
            streams=None):
     stream_event = MockResult("ok: ok")
-    monkeypatch.setattr(StreamManager, '__init__', MockStreamManager.__init__)
-    monkeypatch.setattr(StreamManager, 'connect', MockStreamManager.connect)
-    monkeypatch.setattr(StreamManager,
+    monkeypatch.setattr(RedisStreamManager, '__init__', MockStreamManager.__init__)
+    monkeypatch.setattr(RedisStreamManager, 'connect', MockStreamManager.connect)
+    monkeypatch.setattr(RedisStreamManager,
                         'ensure_consumer_group', MockStreamManager.ensure_consumer_group)
-    monkeypatch.setattr(StreamManager, 'write_stream', MockStreamManager.write_stream)
-    monkeypatch.setattr(StreamManager, 'read_stream', MockStreamManager.read_stream)
-    monkeypatch.setattr(StreamManager, 'ack_read_stream', MockStreamManager.ack_read_stream)
-    monkeypatch.setattr(StreamManager, 'close', MockStreamManager.close)
+    monkeypatch.setattr(RedisStreamManager, 'write_stream', MockStreamManager.write_stream)
+    monkeypatch.setattr(RedisStreamManager, 'read_stream', MockStreamManager.read_stream)
+    monkeypatch.setattr(RedisStreamManager, 'ack_read_stream', MockStreamManager.ack_read_stream)
+    monkeypatch.setattr(RedisStreamManager, 'close', MockStreamManager.close)
     monkeypatch.setattr(MockStreamManager, 'test_payload', stream_event)
     monkeypatch.setattr(MockEventHandler, 'test_track_ids', None)
 

--- a/engine/test/mock_engine/__init__.py
+++ b/engine/test/mock_engine/__init__.py
@@ -6,7 +6,7 @@ from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.dataobjects import DataObject, EventPayload
 from hopeit.server.events import EventHandler
 from hopeit.server.engine import Server
-from hopeit.server.streams import StreamManager, StreamEvent, StreamOSError
+from hopeit.streams import StreamManager, StreamEvent, StreamOSError
 from hopeit.app.config import AppConfig, EventDescriptor, Serialization, Compression
 from hopeit.server.engine import AppEngine
 

--- a/engine/test/unit/server/test_engine.py
+++ b/engine/test/unit/server/test_engine.py
@@ -4,7 +4,8 @@ from typing import Dict, Optional
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.server.config import AuthType
 from hopeit.server.events import EventHandler
-from hopeit.server.streams import StreamManager, StreamOSError
+from hopeit.streams import StreamOSError
+from hopeit.streams.redis import RedisStreamManager
 
 from hopeit.dataobjects import DataObject
 from hopeit.app.config import AppConfig
@@ -60,14 +61,14 @@ def setup_mocks(monkeypatch):
     monkeypatch.setattr(EventHandler, '__init__', MockEventHandler.__init__)
     monkeypatch.setattr(EventHandler, 'handle_async_event', MockEventHandler.handle_async_event)
     monkeypatch.setattr(EventHandler, 'postprocess', MockEventHandler.postprocess)
-    monkeypatch.setattr(StreamManager, '__init__', MockStreamManager.__init__)
-    monkeypatch.setattr(StreamManager, 'connect', MockStreamManager.connect)
-    monkeypatch.setattr(StreamManager, 'write_stream', MockStreamManager.write_stream)
-    monkeypatch.setattr(StreamManager,
+    monkeypatch.setattr(RedisStreamManager, '__init__', MockStreamManager.__init__)
+    monkeypatch.setattr(RedisStreamManager, 'connect', MockStreamManager.connect)
+    monkeypatch.setattr(RedisStreamManager, 'write_stream', MockStreamManager.write_stream)
+    monkeypatch.setattr(RedisStreamManager,
                         'ensure_consumer_group', MockStreamManager.ensure_consumer_group)
-    monkeypatch.setattr(StreamManager, 'read_stream', MockStreamManager.read_stream)
-    monkeypatch.setattr(StreamManager, 'ack_read_stream', MockStreamManager.ack_read_stream)
-    monkeypatch.setattr(StreamManager, 'close', MockStreamManager.close)
+    monkeypatch.setattr(RedisStreamManager, 'read_stream', MockStreamManager.read_stream)
+    monkeypatch.setattr(RedisStreamManager, 'ack_read_stream', MockStreamManager.ack_read_stream)
+    monkeypatch.setattr(RedisStreamManager, 'close', MockStreamManager.close)
 
 
 @pytest.mark.asyncio

--- a/engine/test/unit/server/test_streams.py
+++ b/engine/test/unit/server/test_streams.py
@@ -9,7 +9,8 @@ from mock_engine import MockStreamManager, MockEventHandler
 from hopeit.dataobjects import dataobject
 from hopeit.server.config import AuthType
 
-from hopeit.server.streams import StreamManager, StreamEvent
+from hopeit.streams import StreamManager, StreamEvent
+from hopeit.streams.redis import RedisStreamManager
 
 
 @dataobject(event_id='value', event_ts='ts')
@@ -25,7 +26,7 @@ class MockInvalidDataEvent:
 
 
 async def create_stream_manager():
-    return await StreamManager(address=MockRedisPool.test_url).connect()
+    return await RedisStreamManager(address=MockRedisPool.test_url).connect()
 
 
 async def write_stream():


### PR DESCRIPTION
**INTERNAL CHANGE:**
Split StreamManager class to support specific implemenations. 
Move Redis Streams specifics to RedisStreamManager class.

This allows future creationg of different StreamManager implementions (i.e. for Kafka or embedded stream managers)
