### PR TITLE
feature(plugins): moved hopeit.toolkit.storage.fs to a plugin

### DIFF
--- a/.github/workflows/hopeit-engine-pypi-publishing.yml
+++ b/.github/workflows/hopeit-engine-pypi-publishing.yml
@@ -36,14 +36,18 @@ jobs:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         make pypi
-    - name: Publish plugin redis_streams on PyPI
+    - name: Publish plugin redis-streams on PyPI
       env: 
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         make PLUGINFOLDER=plugins/streams/redis pypi-plugin
-    - name: Publish plugin redis_storage on PyPI
+    - name: Publish plugin redis-storage on PyPI
       env: 
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        make PLUGINFOLDER=plugins/storage/redis pypi-plugin
-        
+        make PLUGINFOLDER=plugins/storage/redis pypi-plugin        
+    - name: Publish plugin fs-storage on PyPI
+      env: 
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        make PLUGINFOLDER=plugins/storage/fs pypi-plugin

--- a/.github/workflows/hopeit-engine-test-pypi-publishing.yml
+++ b/.github/workflows/hopeit-engine-test-pypi-publishing.yml
@@ -41,3 +41,8 @@ jobs:
         TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN_ALL }}
       run: |
         make PLUGINFOLDER=plugins/streams/redis pypi-test-plugin
+    - name: Publish plugin fs_storage on Test PyPI
+      env: 
+        TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN_ALL }}
+      run: |
+        make PLUGINFOLDER=plugins/storage/fs pypi-test-plugin

--- a/apps/benchmark/simple-benchmark/src/simple_benchmark/query_something_fs.py
+++ b/apps/benchmark/simple-benchmark/src/simple_benchmark/query_something_fs.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, StatusType, Status, SomethingNotFound
 
 __steps__ = ['load', 'update_status_history']

--- a/apps/benchmark/simple-benchmark/src/simple_benchmark/save_something_fs.py
+++ b/apps/benchmark/simple-benchmark/src/simple_benchmark/save_something_fs.py
@@ -8,7 +8,7 @@ from typing import Optional
 from hopeit.app.api import event_api
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.context import EventContext
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 
 from model import Something, User, SomethingParams
 

--- a/apps/build/ci-static-apps.sh
+++ b/apps/build/ci-static-apps.sh
@@ -3,11 +3,11 @@ echo "CI STATIC ANALYSIS: APPS"
 echo "========================"
 code=0
 # test/simple-example
-export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages -p common -p model -p simple_example
+export MYPYPATH=engine/src/:plugins/storage/fs/src:engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages -p common -p model -p simple_example
 code+=$?
-export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages apps/examples/simple-example/test/unit/
+export MYPYPATH=engine/src/:plugins/storage/fs/src:engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages apps/examples/simple-example/test/unit/
 code+=$?
-export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages apps/examples/simple-example/test/integration/
+export MYPYPATH=engine/src/:plugins/storage/fs/src:engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m mypy --namespace-packages apps/examples/simple-example/test/integration/
 code+=$?
 python3 -m flake8 --max-line-length=120 apps/examples/simple-example/src/ apps/examples/simple-example/test/unit/ apps/examples/simple-example/test/integration/
 code+=$?

--- a/apps/build/ci-test-apps.sh
+++ b/apps/build/ci-test-apps.sh
@@ -3,7 +3,7 @@ echo "CI TEST: APPS"
 echo "============="
 code=0
 # test/simple-example
-export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=apps/examples/simple-example/src/ apps/examples/simple-example/test/unit/ apps/examples/simple-example/test/integration/
+export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:plugins/storage/fs/src:apps/examples/simple-example/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=apps/examples/simple-example/src/ apps/examples/simple-example/test/unit/ apps/examples/simple-example/test/integration/
 code+=$?
 
 if [ $code -gt 0 ]

--- a/apps/examples/simple-example/setup.py
+++ b/apps/examples/simple-example/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="simple_example",
-    version="0.2.0",
+    version="0.3.0",
     description="Hopeit.py Example App",
     package_dir={
         "": "src"
@@ -14,7 +14,8 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=[
-        "hopeit.engine"
+        "hopeit.engine",
+        "hopeit.fs-storage"
     ],
     extras_require={
     },

--- a/apps/examples/simple-example/src/simple_example/collector/collect_spawn.py
+++ b/apps/examples/simple-example/src/simple_example/collector/collect_spawn.py
@@ -16,7 +16,7 @@ from hopeit.app.logger import app_extra_logger
 from hopeit.dataobjects import dataobject
 from hopeit.server.collector import Collector
 from hopeit.server.steps import SHUFFLE
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, SomethingNotFound
 
 

--- a/apps/examples/simple-example/src/simple_example/collector/query_concurrently.py
+++ b/apps/examples/simple-example/src/simple_example/collector/query_concurrently.py
@@ -14,7 +14,7 @@ from hopeit.app.events import collector_step
 from hopeit.app.logger import app_extra_logger
 from hopeit.dataobjects import dataobject
 from hopeit.server.collector import Collector
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, SomethingNotFound
 
 

--- a/apps/examples/simple-example/src/simple_example/list_somethings.py
+++ b/apps/examples/simple-example/src/simple_example/list_somethings.py
@@ -8,7 +8,7 @@ from typing import Optional, List
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something
 
 __steps__ = ['load_all']

--- a/apps/examples/simple-example/src/simple_example/query_something.py
+++ b/apps/examples/simple-example/src/simple_example/query_something.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, StatusType, Status, SomethingNotFound
 
 __steps__ = ['load', 'update_status_history']

--- a/apps/examples/simple-example/src/simple_example/query_something_extended.py
+++ b/apps/examples/simple-example/src/simple_example/query_something_extended.py
@@ -10,7 +10,7 @@ from common.validation import validate
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, Status, SomethingNotFound
 
 __steps__ = ['load', 'save_with_updated_status']

--- a/apps/examples/simple-example/src/simple_example/save_something.py
+++ b/apps/examples/simple-example/src/simple_example/save_something.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 from hopeit.app.api import event_api
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.context import EventContext, PreprocessHook
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 
 from model import Something, User, SomethingParams
 from common.validation import validate

--- a/apps/examples/simple-example/src/simple_example/service/something_generator.py
+++ b/apps/examples/simple-example/src/simple_example/service/something_generator.py
@@ -10,7 +10,7 @@ import random
 from hopeit.app.events import Spawn
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.context import EventContext
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 
 from model import Something, User, SomethingParams
 

--- a/apps/examples/simple-example/src/simple_example/shuffle/parallelize_event.py
+++ b/apps/examples/simple-example/src/simple_example/shuffle/parallelize_event.py
@@ -14,7 +14,7 @@ from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.dataobjects import dataobject
 from hopeit.app.events import Spawn, SHUFFLE
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, Status, StatusType
 
 logger, extra = app_extra_logger()

--- a/apps/examples/simple-example/src/simple_example/shuffle/spawn_event.py
+++ b/apps/examples/simple-example/src/simple_example/shuffle/spawn_event.py
@@ -13,7 +13,7 @@ from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.dataobjects import dataobject
 from hopeit.app.events import Spawn, SHUFFLE
 from hopeit.app.logger import app_extra_logger
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, Status, StatusType
 
 logger, extra = app_extra_logger()

--- a/apps/examples/simple-example/src/simple_example/streams/process_events.py
+++ b/apps/examples/simple-example/src/simple_example/streams/process_events.py
@@ -10,7 +10,7 @@ from typing import Optional
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.context import EventContext
 from hopeit.dataobjects import dataobject
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
 from model import Something, Status, StatusType
 
 __steps__ = ['update_status', 'save']

--- a/docs/source/apidocs/hopeit.toolkit.rst
+++ b/docs/source/apidocs/hopeit.toolkit.rst
@@ -6,14 +6,6 @@ hopeit.toolkit package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
-
-.. toctree::
-   :maxdepth: 6
-
-   hopeit.toolkit.storage
-
 Submodules
 ----------
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,15 +3,14 @@ Release Notes
 
 Version 0.3.0
 _____________
-- Moved `hopeit.toolkit.storage.redis` to `hopeit.redis-storage` plugin that needs to be installed separately from `hopeit.engine`
+- [Breaking] Moved `hopeit.toolkit.storage.redis` to `hopeit.redis-storage` plugin.
     - Install using `pip install hopeit.redis-storage`
-
-Version 0.2.4
-_____________
-- Moved RedisStreamManager to its own plugin. 
-- [Breaking/Config] By default `stream-manager` is not configured. To enable Redis Streams in server:
-    - Install using `pip install hopeit.engine[redis-streams]`
-    - Add `stream_manager=hopeit.redis_streams.RedisStreamManager` to streams section in server config file.
+- [Breaking] Moved `hopeit.toolkit.storage.fs` to `hopeit.fs-storage` plugin.
+    - Install using `pip install hopeit.fs-storage`
+- [Breaking] Moved RedisStreamManager to its own plugin. 
+    - By default `stream-manager` is not configured. To enable Redis Streams in server:
+        - Install using `pip install hopeit.engine[redis-streams]`
+        - Add `stream_manager=hopeit.redis_streams.RedisStreamManager` to streams section in server config file.
 
 
 Version 0.2.3

--- a/docs/source/tutorials/05-streams.rst
+++ b/docs/source/tutorials/05-streams.rst
@@ -253,7 +253,7 @@ Notice that we’ve introduced several new concepts:
 
     from hopeit.app.context import EventContext
     from hopeit.app.logger import app_extra_logger
-    from hopeit.toolkit.storage.fs import FileStorage
+    from hopeit.fs_storage import FileStorage
 
     from .data_model import Status, MyMessage
 

--- a/engine/requirements-dev.txt
+++ b/engine/requirements-dev.txt
@@ -10,3 +10,4 @@ coverage-badge
 mypy
 wheel
 docker-compose
+aiofiles

--- a/engine/requirements.lock
+++ b/engine/requirements.lock
@@ -1,4 +1,3 @@
-aiofiles==0.6.0
 aiohttp==3.7.4.post0
 aiohttp-cors==0.7.0
 aiohttp-swagger3==0.5.4

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -2,7 +2,6 @@ aiohttp
 aiohttp-cors
 aiohttp-swagger3==0.5.4
 aiojobs
-aiofiles
 dataclasses-jsonschema[fast-validation]
 stringcase
 aioredis

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -59,14 +59,12 @@ setuptools.setup(
         "hopeit.server",
         "hopeit.streams",
         "hopeit.testing",
-        "hopeit.toolkit", 
-        "hopeit.toolkit.storage"
+        "hopeit.toolkit"
     ],
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=[ f"{lib}>={libversion(lib)}" for lib in [
         "aiojobs",
-        "aiofiles",
         "lz4",
         "stringcase",
         "PyJWT[crypto]",

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -3,4 +3,4 @@ Engine version constants.
 Increment on release
 """
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.3.0rc1"
+ENGINE_VERSION = "0.3.0rc2"

--- a/engine/src/hopeit/toolkit/storage/__init__.py
+++ b/engine/src/hopeit/toolkit/storage/__init__.py
@@ -1,4 +1,0 @@
-"""
-hopeit.engine toolkit.storage module
-
-"""

--- a/engine/src/hopeit/toolkit/storage/__init__.py
+++ b/engine/src/hopeit/toolkit/storage/__init__.py
@@ -1,7 +1,4 @@
 """
 hopeit.engine toolkit.storage module
 
-Storage/persistence methods supported by the engine
-    * **fs**: asynchronous read/write to local filesystem
 """
-__all__ = ['fs']

--- a/plugins/build/ci-static-plugins.sh
+++ b/plugins/build/ci-static-plugins.sh
@@ -34,6 +34,16 @@ code+=$?
 python3 -m pylint plugins/storage/redis/src/hopeit/redis_storage/
 code+=$?
 
+# storage/fs
+export MYPYPATH=engine/src/:plugins/storage/fs/src/ && python3 -m mypy --namespace-packages -p hopeit.fs_storage
+code+=$?
+export MYPYPATH=engine/src/:plugins/storage/fs/src/ && python3 -m mypy --namespace-packages plugins/storage/fs/test/unit/
+code+=$?
+python3 -m flake8 --max-line-length=120 plugins/storage/fs/src/hopeit/ plugins/storage/fs/test/unit/
+code+=$?
+python3 -m pylint plugins/storage/fs/src/hopeit/fs_storage/
+code+=$?
+
 if [ $code -gt 0 ]
 then
   echo "[FAILED] CI STATIC ANALYSIS: PLUGINS"

--- a/plugins/build/ci-test-plugins.sh
+++ b/plugins/build/ci-test-plugins.sh
@@ -14,6 +14,10 @@ code+=$?
 export PYTHONPATH=engine/src/:plugins/storage/redis/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=plugins/storage/redis/src plugins/storage/redis/test/unit/
 code+=$?
 
+# storage/fs
+export PYTHONPATH=engine/src/:plugins/storage/fs/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=plugins/storage/fs/src/ plugins/storage/fs/test/unit/
+code+=$?
+
 if [ $code -gt 0 ]
 then
   echo "[FAILED] CI TEST: PLUGINS"

--- a/plugins/storage/fs/README.md
+++ b/plugins/storage/fs/README.md
@@ -1,4 +1,4 @@
-# hopeit.engine fs-storage plugins
+# hopeit.engine fs-storage plugin
 
 
 This library is part of hopeit.engine:

--- a/plugins/storage/fs/README.md
+++ b/plugins/storage/fs/README.md
@@ -1,0 +1,13 @@
+# hopeit.engine fs-storage plugins
+
+
+This library is part of hopeit.engine:
+
+> check: https://github.com/hopeit-git/hopeit.engine
+
+
+### Install using pip:
+
+```
+pip install hopeit.fs-storage
+```

--- a/plugins/storage/fs/setup.py
+++ b/plugins/storage/fs/setup.py
@@ -1,0 +1,53 @@
+import setuptools
+
+version = {}
+with open("../../../engine/src/hopeit/server/version.py") as fp:
+    exec(fp.read(), version)
+
+setuptools.setup(
+    name="hopeit.fs-storage",
+    version=version['ENGINE_VERSION'],
+    description="Hopeit Engine File System Storage Toolkit",
+    license="Apache 2",
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
+    author="Leo Smerling and Pablo Canto",
+    author_email="contact@hopeit.com.ar",
+    url="https://github.com/hopeit-git/hopeit.engine",
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Development Status :: 4 - Beta",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Framework :: AsyncIO",
+    ],    
+    project_urls={
+        "CI: GitHub Actions": "https://github.com/hopeit-git/hopeit.engine/actions?query=workflow",  # noqa
+        "Docs: RTD": "https://hopeitengine.readthedocs.io/en/latest/",
+        "GitHub: issues": "https://github.com/hopeit-git/hopeit.engine/issues",
+        "GitHub: repo": "https://github.com/hopeit-git/hopeit.engine",
+    },
+    package_dir={
+        "": "src"
+    },
+    packages=[
+        "hopeit.fs_storage"
+    ],
+    include_package_data=True,
+    python_requires=">=3.7",
+    install_requires=[
+        f"hopeit.engine=={version['ENGINE_VERSION']}",
+        "aiofiles"
+    ],
+    extras_require={
+    },
+    entry_points={
+    }
+)

--- a/plugins/storage/fs/src/hopeit/fs_storage/__init__.py
+++ b/plugins/storage/fs/src/hopeit/fs_storage/__init__.py
@@ -1,5 +1,6 @@
 """
-Helpers to load an save from local filesystem
+Storage/persistence asynchronous stores and gets dataobjects from filesystem.
+
 """
 import os
 from glob import glob

--- a/plugins/storage/fs/test/unit/test_fs.py
+++ b/plugins/storage/fs/test/unit/test_fs.py
@@ -1,13 +1,14 @@
 from typing import List
-import pytest  # type: ignore
+
 import os
 from dataclasses import dataclass
 
 import aiofiles  # type: ignore
 
-from hopeit.toolkit.storage import fs as fs_module
+import hopeit.fs_storage as fs_module
 from hopeit.dataobjects import dataobject
-from hopeit.toolkit.storage.fs import FileStorage
+from hopeit.fs_storage import FileStorage
+import pytest  # type: ignore
 
 
 @dataobject


### PR DESCRIPTION
MOTIVATION:
===========
Current version of hopeit.engine provides a toolkit for help easy way to stores and retrieves dataobjects to filesystem. This feature will be accomplished by a plugin 

Plugins can be executed Standalone.

This plugin will be released as a python library and can be installed optionally when installing hopeit.engine with extras [fs-storage].

CHANGES ON THIS PR
===================
- [x] Move  `hopeit.toolkit.storage.fs` to a plugin: `hopeit.fs_storage`
- [x] Adapt CI to release `fs-storage` plugin to PyPi

CURRENT STATUS
===============
Ready for initial testing. Backwards compatible with previous implementation (*)

*Requires change on import:
1 - Install hopeit.engine using [fs-storage] plugin extras:

```
 pip install hopeit.fs-storage
```

2 - Change import signature

From:
```
from hopeit.toolkit.storage.fs import FileStorage
```
To:
```
from hopeit.fs_storage import FileStorage
```
