### PR TITLE
fix(apps/plugins): Match app/plugins version with engine release

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "simple-example",
+            "type": "python",
+            "request": "launch",
+            "module": "hopeit.server.web",
+            "args": [
+                "--port=8020",
+                "--start-streams",
+                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
+                "--api-file=apps/examples/simple-example/api/openapi.json"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/apps/benchmark/simple-benchmark/api/create_api_file.sh
+++ b/apps/benchmark/simple-benchmark/api/create_api_file.sh
@@ -1,1 +1,6 @@
-export PYTHONPATH=../src && hopeit_openapi create --config-files=../config/dev-noauth.json,../config/1x0.json --output-file=../api/openapi.json --api-version=0.3.0 --title="Simple Benchmark" --description="Simple Benchmark App"
+export PYTHONPATH=../src && hopeit_openapi create \
+--config-files=../config/dev-noauth.json,../config/app-config.json \
+--output-file=../api/openapi.json \
+--api-version=$(python -m hopeit.server.version) \
+--title="Simple Benchmark" \
+--description="Simple Benchmark App"

--- a/apps/benchmark/simple-benchmark/config/app-config-docker.json
+++ b/apps/benchmark/simple-benchmark/config/app-config-docker.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "name": "simple-benchmark",
-    "version": "1.0"
+    "version": "${HOPEIT_ENGINE_VERSION}"
   },
   "engine" : {
     "import_modules": ["simple_benchmark"]
@@ -11,11 +11,11 @@
       "data_path": "/tmp/{auto}/"
     },
     "redis": {
-      "address": "redis://localhost:6379"
+      "address": "redis://redis:6379"
     }
   },
   "events": {
-    "give_me_something": {
+   "give_me_something": {
       "type": "GET"
     },
     "query_something_fs": {

--- a/apps/benchmark/simple-benchmark/config/app-config.json
+++ b/apps/benchmark/simple-benchmark/config/app-config.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "name": "simple-benchmark",
-    "version": "1.0"
+    "version": "${HOPEIT_ENGINE_VERSION}"
   },
   "engine" : {
     "import_modules": ["simple_benchmark"]
@@ -11,11 +11,11 @@
       "data_path": "/tmp/{auto}/"
     },
     "redis": {
-      "address": "redis://redis:6379"
+      "address": "redis://localhost:6379"
     }
   },
   "events": {
-   "give_me_something": {
+    "give_me_something": {
       "type": "GET"
     },
     "query_something_fs": {

--- a/apps/benchmark/simple-benchmark/docker/bench-engine/config/supervisord.conf
+++ b/apps/benchmark/simple-benchmark/docker/bench-engine/config/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/opt/hopeit.py/logs/engine_%(process_num)s.log
 redirect_stderr=true
 
 ; Unix socket paths are specified by command line.
-command=hopeit_server run --port=802%(process_num)s --config-files=config/dev-noauth-docker.json,config/1x0-docker.json --api-file=api/openapi.json --host=0.0.0.0 --start-streams
+command=hopeit_server run --port=802%(process_num)s --config-files=config/dev-noauth-docker.json,config/config-docker.json --api-file=api/openapi.json --host=0.0.0.0 --start-streams
 
 user=root
 autostart=true

--- a/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
+++ b/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"

--- a/apps/benchmark/simple-benchmark/test/start-local.sh
+++ b/apps/benchmark/simple-benchmark/test/start-local.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo Starting hopeit.engine on http://localhost:8021 ...
-export PYTHONPATH=../src && nohup hopeit_server run --port=8021 --config-files=../config/dev-noauth.json,../config/1x0.json --api-file=../api/openapi.json  > local.log 2>&1 & echo $! > local.pid
+export PYTHONPATH=../src && nohup hopeit_server run --port=8021 --config-files=../config/dev-noauth.json,../config/app-config.json --api-file=../api/openapi.json  > local.log 2>&1 & echo $! > local.pid

--- a/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
+++ b/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
@@ -7,6 +7,6 @@ else
   host=localhost
 fi
 for i in {1..2000}; do
-  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/1x0/save-something-fs"
+  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/0x3x0/save-something-fs"
 done
 echo Done.

--- a/apps/examples/simple-example/api/create-openapi-file.sh
+++ b/apps/examples/simple-example/api/create-openapi-file.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
-cd ../../../../
-hopeit_openapi create --title="Simple Example" --description="Simple Example" --api-version="0.2.0" --config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/1x0.json,apps/examples/simple-example/config/1x0.json --output-file=apps/examples/simple-example/api/openapi.json
+hopeit_openapi create \
+--title="Simple Example" \
+--description="Simple Example" \
+--api-version="$(python -m hopeit.server.version)" \
+--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json \
+--output-file=apps/examples/simple-example/api/openapi.json

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.2.0",
+    "version": "0.3.0rc4",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/basic-auth/2x0/decode": {
+    "/api/basic-auth/0x3x0rc4/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.2x0"
+          "basic_auth.0x3x0rc4"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/list-somethings": {
+    "/api/simple-example/0x3x0rc4/list-somethings": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -123,7 +123,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -132,7 +132,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/query-something": {
+    "/api/simple-example/0x3x0rc4/query-something": {
       "get": {
         "summary": "Simple Example: Query Something",
         "description": "Loads Something from disk",
@@ -209,7 +209,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -304,7 +304,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -313,7 +313,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/save-something": {
+    "/api/simple-example/0x3x0rc4/save-something": {
       "post": {
         "summary": "Simple Example: Save Something",
         "description": "Creates and saves Something",
@@ -410,7 +410,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -419,7 +419,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/download-something": {
+    "/api/simple-example/0x3x0rc4/download-something": {
       "get": {
         "summary": "Simple Example: Download Something",
         "description": "Download image file. The PostprocessHook return the requested file as stream.",
@@ -506,7 +506,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -515,7 +515,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/upload-something": {
+    "/api/simple-example/0x3x0rc4/upload-something": {
       "post": {
         "summary": "Simple Example: Multipart Upload files",
         "description": "Upload files using Multipart form request",
@@ -653,7 +653,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -662,7 +662,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/streams/something-event": {
+    "/api/simple-example/0x3x0rc4/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
         "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
@@ -731,7 +731,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -740,7 +740,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/collector/query-concurrently": {
+    "/api/simple-example/0x3x0rc4/collector/query-concurrently": {
       "post": {
         "summary": "Simple Example: Query Concurrently",
         "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
@@ -812,7 +812,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -821,7 +821,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/collector/collect-spawn": {
+    "/api/simple-example/0x3x0rc4/collector/collect-spawn": {
       "post": {
         "summary": "Simple Example: Collect and Spawn",
         "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
@@ -899,7 +899,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -908,7 +908,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/shuffle/spawn-event": {
+    "/api/simple-example/0x3x0rc4/shuffle/spawn-event": {
       "post": {
         "summary": "Simple Example: Spawn Event",
         "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
@@ -986,7 +986,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -995,7 +995,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/shuffle/parallelize-event": {
+    "/api/simple-example/0x3x0rc4/shuffle/parallelize-event": {
       "post": {
         "summary": "Simple Example: Parallelize Event",
         "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
@@ -1073,7 +1073,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -1082,7 +1082,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/basic-auth/2x0/login": {
+    "/api/simple-example/0x3x0rc4/basic-auth/0x3x0rc4/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -1150,7 +1150,7 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
@@ -1159,7 +1159,7 @@
         ]
       }
     },
-    "/api/simple-example/2x0/basic-auth/2x0/refresh": {
+    "/api/simple-example/0x3x0rc4/basic-auth/0x3x0rc4/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -1227,16 +1227,16 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
-            "simple_example.2x0.refresh": []
+            "simple_example.0x3x0rc4.refresh": []
           }
         ]
       }
     },
-    "/api/simple-example/2x0/basic-auth/2x0/logout": {
+    "/api/simple-example/0x3x0rc4/basic-auth/0x3x0rc4/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -1313,11 +1313,11 @@
           }
         },
         "tags": [
-          "simple_example.2x0"
+          "simple_example.0x3x0rc4"
         ],
         "security": [
           {
-            "simple_example.2x0.refresh": []
+            "simple_example.0x3x0rc4.refresh": []
           }
         ]
       }
@@ -1518,10 +1518,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "simple_example.2x0.refresh": {
+      "simple_example.0x3x0rc4.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "simple_example.2x0.refresh"
+        "name": "simple_example.0x3x0rc4.refresh"
       }
     }
   },

--- a/apps/examples/simple-example/config/app-config.json
+++ b/apps/examples/simple-example/config/app-config.json
@@ -1,10 +1,10 @@
 {
   "app": {
     "name": "simple-example",
-    "version": "2.0"
+    "version": "${HOPEIT_ENGINE_VERSION}"
   },
   "plugins": [
-    {"name": "basic-auth", "version": "2.0"}
+    {"name": "basic-auth", "version": "${HOPEIT_ENGINE_VERSION}"}
   ],
   "engine" : {
     "import_modules": ["simple_example"],

--- a/apps/examples/simple-example/test/integration/conftest.py
+++ b/apps/examples/simple-example/test/integration/conftest.py
@@ -78,4 +78,4 @@ def something_with_status_processed_example():
 
 @pytest.fixture
 def app_config():
-    return config('apps/examples/simple-example/config/1x0.json')
+    return config('apps/examples/simple-example/config/app-config.json')

--- a/apps/examples/simple-example/test/integration/test_it_collect_spawn.py
+++ b/apps/examples/simple-example/test/integration/test_it_collect_spawn.py
@@ -4,8 +4,12 @@ import uuid
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
+
 from model import Something
 from simple_example.collector.collect_spawn import ItemsInfo, ItemsCollected
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.fixture
@@ -14,8 +18,8 @@ def sample_file_ids():
     for test_id in ids:
         json_str = '{"id": "' + test_id + '", "user": {"id": "u1", "name": "test_user"}, ' \
                    + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
-        os.makedirs('/tmp/simple_example.2x0.fs.data_path/', exist_ok=True)
-        with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id}.json', 'w') as f:
+        os.makedirs(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/', exist_ok=True)
+        with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id}.json', 'w') as f:
             f.write(json_str)
             f.flush()
     return ids

--- a/apps/examples/simple-example/test/integration/test_it_download_something.py
+++ b/apps/examples/simple-example/test/integration/test_it_download_something.py
@@ -1,6 +1,9 @@
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.mark.asyncio
@@ -18,7 +21,7 @@ async def test_it_download_something(app_config, something_params_example,
     )
 
     ret_header = {'Content-Disposition': f'attachment; filename={file_name}', 'Content-Type': 'image/png'}
-    ret_file_response = f"/tmp/simple_example.2x0.fs.data_path/{file_name}"
+    ret_file_response = f"/tmp/simple_example.{APP_VERSION}.fs.data_path/{file_name}"
     ret__ = f"File {file_name}"
 
     assert response.headers == ret_header

--- a/apps/examples/simple-example/test/integration/test_it_list_somethings.py
+++ b/apps/examples/simple-example/test/integration/test_it_list_somethings.py
@@ -4,7 +4,11 @@ import uuid
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
+
 from model import Something
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.fixture
@@ -16,11 +20,11 @@ def sample_file_id():
                 + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
     json_str2 = '{"id": "' + test_id2 + '", "user": {"id": "u1", "name": "test_user"}, ' \
                 + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
-    os.makedirs('/tmp/simple_example.2x0.fs.data_path/', exist_ok=True)
-    with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id1}.json', 'w') as f:
+    os.makedirs(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/', exist_ok=True)
+    with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id1}.json', 'w') as f:
         f.write(json_str1)
         f.flush()
-    with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id2}.json', 'w') as f:
+    with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id2}.json', 'w') as f:
         f.write(json_str2)
         f.flush()
     return test_id

--- a/apps/examples/simple-example/test/integration/test_it_query_concurrently.py
+++ b/apps/examples/simple-example/test/integration/test_it_query_concurrently.py
@@ -4,7 +4,11 @@ import uuid
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
+
 from simple_example.collector.query_concurrently import ItemsInfo
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.fixture
@@ -13,8 +17,8 @@ def sample_file_ids():
     for test_id in ids:
         json_str = '{"id": "' + test_id + '", "user": {"id": "u1", "name": "test_user"}, ' \
                    + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
-        os.makedirs('/tmp/simple_example.2x0.fs.data_path/', exist_ok=True)
-        with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id}.json', 'w') as f:
+        os.makedirs(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/', exist_ok=True)
+        with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id}.json', 'w') as f:
             f.write(json_str)
             f.flush()
     return ids

--- a/apps/examples/simple-example/test/integration/test_it_query_something.py
+++ b/apps/examples/simple-example/test/integration/test_it_query_something.py
@@ -4,8 +4,11 @@ import uuid
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
 
 from model import Something, SomethingNotFound
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.fixture
@@ -13,8 +16,8 @@ def sample_file_id():
     test_id = str(uuid.uuid4())
     json_str = '{"id": "' + test_id + '", "user": {"id": "u1", "name": "test_user"}, ' \
                + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
-    os.makedirs('/tmp/simple_example.2x0.fs.data_path/', exist_ok=True)
-    with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id}.json', 'w') as f:
+    os.makedirs(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/', exist_ok=True)
+    with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id}.json', 'w') as f:
         f.write(json_str)
         f.flush()
     return test_id
@@ -43,4 +46,4 @@ async def test_query_item_not_found(app_config):  # noqa: F811
     assert res.status == 404
     assert result == pp_result
     assert result == SomethingNotFound(
-        path='/tmp/simple_example.2x0.fs.data_path', id=item_id)
+        path=f'/tmp/simple_example.{APP_VERSION}.fs.data_path', id=item_id)

--- a/apps/examples/simple-example/test/integration/test_it_query_something_extended.py
+++ b/apps/examples/simple-example/test/integration/test_it_query_something_extended.py
@@ -5,8 +5,11 @@ from datetime import datetime, timezone
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
 
 from model import Something, SomethingNotFound, Status, StatusType
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.fixture
@@ -14,8 +17,8 @@ def sample_file_id():
     test_id = str(uuid.uuid4())
     json_str = '{"id": "' + test_id + '", "user": {"id": "u1", "name": "test_user"}, ' \
                + '"status": {"ts": "2020-05-01T00:00:00Z", "type": "NEW"}, "history": []}'
-    os.makedirs('/tmp/simple_example.2x0.fs.data_path/', exist_ok=True)
-    with open(f'/tmp/simple_example.2x0.fs.data_path/{test_id}.json', 'w') as f:
+    os.makedirs(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/', exist_ok=True)
+    with open(f'/tmp/simple_example.{APP_VERSION}.fs.data_path/{test_id}.json', 'w') as f:
         f.write(json_str)
         f.flush()
     return test_id
@@ -47,4 +50,4 @@ async def test_query_item_not_found(app_config):  # noqa: F811
     assert res.status == 404
     assert result == pp_result
     assert result == SomethingNotFound(
-        path='/tmp/simple_example.2x0.fs.data_path', id=item_id)
+        path=f'/tmp/simple_example.{APP_VERSION}.fs.data_path', id=item_id)

--- a/apps/examples/simple-example/test/integration/test_it_upload_something.py
+++ b/apps/examples/simple-example/test/integration/test_it_upload_something.py
@@ -1,6 +1,9 @@
 import pytest  # type: ignore
 
 from hopeit.testing.apps import execute_event
+from hopeit.server.version import ENGINE_VERSION
+
+APP_VERSION = ENGINE_VERSION.replace('.', "x")
 
 
 @pytest.mark.asyncio
@@ -26,7 +29,10 @@ async def test_it_save_something(app_config, something_params_example, something
 
     assert result == [something_upload_example]
 
-    with open('/tmp/simple_example.2x0.upload_something.save_path/attachment-test_file_name.bytes', 'rb') as f:
+    with open(
+        f'/tmp/simple_example.{APP_VERSION}.upload_something.save_path/attachment-test_file_name.bytes',
+        'rb'
+    ) as f:
         data = f.read()
 
     assert data == upload['attachment']

--- a/docker/engine/config/supervisord.conf
+++ b/docker/engine/config/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/opt/hopeit.engine/logs/engine_%(process_num)s.log
 redirect_stderr=true
 
 ; Unix socket paths are specified by command line.
-command=python engine/src/hopeit/server/web.py --port=802%(process_num)s  --config-files=engine/config/dev-docker.json,plugins/auth/basic-auth/config/1x0.json,apps/examples/simple-example/config/1x0.json
+command=python engine/src/hopeit/server/web.py --port=802%(process_num)s  --config-files=engine/config/dev-docker.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json
 
 user=root
 autostart=true
@@ -30,7 +30,7 @@ stdout_logfile=/opt/hopeit.engine/logs/streams_%(process_num)s.log
 redirect_stderr=true
 
 ; Unix socket paths are specified by command line.
-command=python engine/src/hopeit/server/web.py --start-streams --path=/tmp/streams_%(process_num)s  --config-files=engine/config/dev-docker.json,apps/examples/simple-example/config/1x0.json
+command=python engine/src/hopeit/server/web.py --start-streams --path=/tmp/streams_%(process_num)s  --config-files=engine/config/dev-docker.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json
 
 user=root
 autostart=true

--- a/docs/source/benchmark/dedicated.rst
+++ b/docs/source/benchmark/dedicated.rst
@@ -12,11 +12,11 @@ real time") for every request in the 99th percentile. The result is a rate (requ
 
 Three endpoints are evaluated in each test scenario
 
-* http://hostname:port/api/simple-benchmark/1x0/give-me-something retrieves information from objects randomly created
+* http://hostname:port/api/simple-benchmark/0x3x0/give-me-something retrieves information from objects randomly created
 
-* http://hostname:port/api/simple-benchmark/1x0/query-something-redis returns information from objects stored on a Redis server (memory store)
+* http://hostname:port/api/simple-benchmark/0x3x0/query-something-redis returns information from objects stored on a Redis server (memory store)
 
-* http://hostname:port/api/simple-benchmark/1x0/query-something-fs retrieves information from objects stored on a file system (SSD drive)
+* http://hostname:port/api/simple-benchmark/0x3x0/query-something-fs retrieves information from objects stored on a file system (SSD drive)
 
 Scenarios:
 __________
@@ -68,13 +68,13 @@ Now we are ready to start the simple-benchmark app to run the tests
 
 Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed starts into account) results:
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
  p99 30.38ms @ 1794.29 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
  p99 27.18ms @ 1226.51 req/s
 
-./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
  p99 31.12ms @ 803.38 req/s
 
 2 . Docker, single/multiple instances of hopeit.engine
@@ -103,22 +103,22 @@ Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed sta
 
 4 hopeit.engine instances behind a reverse proxy
 
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
  p99 27.77ms @ 2587.95 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
  p99 28.67ms @ 1810.14 req/s
 
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/1x0/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
  p99 30.29ms @ 1241.39 req/s
 
 1 hopeit.engine instance
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/give-me-something?item_id=string"
  p99 26.48ms @ 1336.18 req/s
 
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-redis?item_id=string"
  p99 29.14ms @ 908.93 req/s
 
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/1x0/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x3x0/query-something-fs?item_id=string"
  p99 24.77ms @ 624.77 req/s

--- a/docs/source/quickstart/dev.rst
+++ b/docs/source/quickstart/dev.rst
@@ -14,7 +14,7 @@ Run example application
  docker-compose up -d redis
  cd ..
 
- hopeit_engine run --port=8020 --start-streams ----config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/1x0.json,apps/examples/simple-example/config/1x0.json --api-file=apps/examples/simple-example/api/openapi.json
+ hopeit_engine run --port=8020 --start-streams ----config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json --api-file=apps/examples/simple-example/api/openapi.json
 
 
 2 - To run and debug using VSCode, add this configuration to your .launch.json file:
@@ -33,7 +33,7 @@ Run example application
             "args": [
                 "--port=8020", 
                 "--start-streams", 
-                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/1x0.json,apps/examples/simple-example/config/1x0.json",
+                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
                 "--api-file=apps/examples/simple-example/api/openapi.json"
             ],
             "cwd": "${workspaceFolder}"

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -3,8 +3,7 @@ Engine version constants.
 Increment on release
 
 To ensure configuration files from example apps and plugins have same version as engine,
-an environment variable `HOPEIT_ENGINE_VERSION` 
-
+an environment variable `HOPEIT_ENGINE_VERSION`
 """
 import os
 

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -1,6 +1,17 @@
 """
 Engine version constants.
 Increment on release
+
+To ensure configuration files from example apps and plugins have same version as engine,
+an environment variable `HOPEIT_ENGINE_VERSION` 
+
 """
+import os
+
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.3.0rc3"
+ENGINE_VERSION = "0.3.0rc4"
+
+os.environ['HOPEIT_ENGINE_VERSION'] = ENGINE_VERSION
+
+if __name__ == "__main__":
+    print(ENGINE_VERSION)

--- a/engine/test/unit/app/test_app_config.py
+++ b/engine/test/unit/app/test_app_config.py
@@ -118,7 +118,7 @@ def _get_env_mock(var_name):
     elif var_name == "HOPEIT_ENGINE_VERSION":
         return ENGINE_VERSION
     raise RuntimeError(f"Missing mocked env {var_name}")
- 
+
 
 def test_parse_app_config_json(monkeypatch,
                                valid_config_json: str,

--- a/plugins/auth/basic-auth/config/plugin-config.json
+++ b/plugins/auth/basic-auth/config/plugin-config.json
@@ -1,7 +1,7 @@
 {
   "app" : {
     "name": "basic-auth",
-    "version": "2.0"
+    "version": "${HOPEIT_ENGINE_VERSION}"
   },
   "engine" : {
     "import_modules": ["hopeit.basic_auth"],

--- a/plugins/auth/basic-auth/test/unit/__init__.py
+++ b/plugins/auth/basic-auth/test/unit/__init__.py
@@ -28,5 +28,5 @@ def mock_app_config():
 
 @pytest.fixture
 def plugin_config():
-    with open('plugins/auth/basic-auth/config/1x0.json', 'r') as f:
+    with open('plugins/auth/basic-auth/config/plugin-config.json', 'r') as f:
         return parse_app_config_json(f.read())


### PR DESCRIPTION
CHANGES:
=========
Configuration changes: matching example apps and plugins version to the engine version.

Matching is done using an env variable HOPEIT_ENGINE_VERSION that is created in version.py

Then plugins and app config json files embedded in the engine repo, use this variable to determine its version.
This way, each release of hopeit.engine will contain also a matching/tested release for plugins and apps.

Renamed config files to app-config.json and plugin-config.json accordingly.
