### PR TITLE
fix(setup): Fix/aiohttp dependency

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,10 +12,11 @@ _____________
         - Install using `pip install hopeit.engine[redis-streams]`
         - Add `stream_manager=hopeit.redis_streams.RedisStreamManager` to streams section in server config file.
 - [Breaking] removed `hopeit.dataobjects.validation` and `hopeit.toolkit.validators` modules
-- [Breaking] make simple-example app to match Major.Minor version number from engine. This is only breaking changes for users of this app config file.
-- [Breaking] make simple-benchmark app to match Major.Minor version number from engine. This is only breaking changes for users of this app config file.
-- [Breaking] make basic-auth plugin to match Major.Minor version number from engine. This is only breaking changes for users of this plugin config file.
+- [Breaking] make simple-example app to match Major. Minor version number from engine. This is only breaking changes for users of this app config file.
+- [Breaking] make simple-benchmark app to match Major. Minor version number from engine. This is only breaking changes for users of this app config file.
+- [Breaking] make basic-auth plugin to match Major. Minor version number from engine. This is only breaking changes for users of this plugin config file.
 - Added test build for Python 3.9
+- Fix: removed aiohttp dependency for hopeit.app.context module, in order to allow engine usage on applications that do not require web server module.
 
 
 Version 0.2.3

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -10,6 +10,7 @@ cryptography>=3.3.1,<3.4
 pyjwt[crypto]>=1.7.0,<2
 click
 deepdiff
+multidict
 fastjsonschema
 typing_inspect
 #idna<3,>=2.5

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -69,21 +69,20 @@ setuptools.setup(
         "lz4",
         "stringcase",
         "PyJWT[crypto]",
-        "click",
         "deepdiff",
-        "typing-inspect"
+        "typing-inspect",
+        "multidict",
+        "dataclasses-jsonschema[fast-validation]",
+        "fastjsonschema"
     ]],
     extras_require={
         "web": [ f"{lib}>={libversion(lib)}" for lib in [
             "aiohttp",
             "aiohttp-cors",
-            "aiohttp-swagger3",
-            "dataclasses-jsonschema[fast-validation]",
-            "fastjsonschema"
+            "aiohttp-swagger3"
         ]],
         "cli": [ f"{lib}>={libversion(lib)}" for lib in [
-            "dataclasses-jsonschema[fast-validation]",
-            "fastjsonschema"
+            "click"
         ]],
         "redis-streams": [
             f"hopeit.redis-streams=={version['ENGINE_VERSION']}"

--- a/engine/src/hopeit/cli/openapi.py
+++ b/engine/src/hopeit/cli/openapi.py
@@ -1,15 +1,22 @@
 """
 CLI openapi commands
 """
+import sys
 import re
 
-import click
-from deepdiff import DeepDiff  # type: ignore
+try:
+    import click
+    from deepdiff import DeepDiff  # type: ignore
 
-from hopeit.app.config import parse_app_config_json
-from hopeit.server import api
-from hopeit.server.config import parse_server_config_json
-from hopeit.server.logger import engine_logger
+    from hopeit.app.config import parse_app_config_json
+    from hopeit.server import api
+    from hopeit.server.config import parse_server_config_json
+    from hopeit.server.logger import engine_logger
+except ModuleNotFoundError:
+    print("ERROR: Missing dependencies."
+            "\n       To use hopeit_server command line tool"
+            "\n       install using `pip install hopeit.engine[web,cli]`")
+    sys.exit(1)
 
 logger = engine_logger().init_cli('openapi')
 setattr(api, 'logger', logger)

--- a/engine/src/hopeit/cli/openapi.py
+++ b/engine/src/hopeit/cli/openapi.py
@@ -14,8 +14,8 @@ try:
     from hopeit.server.logger import engine_logger
 except ModuleNotFoundError:
     print("ERROR: Missing dependencies."
-            "\n       To use hopeit_server command line tool"
-            "\n       install using `pip install hopeit.engine[web,cli]`")
+          "\n       To use hopeit_server command line tool"
+          "\n       install using `pip install hopeit.engine[web,cli]`")
     sys.exit(1)
 
 logger = engine_logger().init_cli('openapi')

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -1,10 +1,16 @@
 """
 CLI server commands
 """
-import click
+import sys
 
-from hopeit.server import web
-
+try:
+    import click
+    from hopeit.server import web
+except ModuleNotFoundError:
+    print("ERROR: Missing dependencies."
+            "\n       To use hopeit_server command line tool"
+            "\n       install using `pip install hopeit.engine[web,cli]`")
+    sys.exit(1)
 
 @click.group()
 def server():
@@ -29,4 +35,4 @@ def run(config_files: str, api_file: str, host: str, port: int, path: str, start
 cli = click.CommandCollection(sources=[server])
 
 if __name__ == '__main__':
-    cli()
+        cli()

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -8,9 +8,10 @@ try:
     from hopeit.server import web
 except ModuleNotFoundError:
     print("ERROR: Missing dependencies."
-            "\n       To use hopeit_server command line tool"
-            "\n       install using `pip install hopeit.engine[web,cli]`")
+          "\n       To use hopeit_server command line tool"
+          "\n       install using `pip install hopeit.engine[web,cli]`")
     sys.exit(1)
+
 
 @click.group()
 def server():
@@ -35,4 +36,4 @@ def run(config_files: str, api_file: str, host: str, port: int, path: str, start
 cli = click.CommandCollection(sources=[server])
 
 if __name__ == '__main__':
-        cli()
+    cli()

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.3.0rc7"
+ENGINE_VERSION = "0.3.0rc8"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -587,7 +587,7 @@ async def _handle_multipart_invocation(
         context = _request_start(app_engine, impl, event_name, request)
         query_args = dict(request.query)
         _validate_authorization(app_engine.app_config, context, auth_types, request)
-        hook = PreprocessHook(
+        hook = PreprocessHook(                                                   # type: ignore
             headers=request.headers, multipart_reader=await request.multipart()  # type: ignore
         )
         return await _request_execute(impl, event_name, context, query_args, payload=None,

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -30,7 +30,7 @@ from hopeit.server import api
 from hopeit.server.steps import find_datatype_handler
 from hopeit.toolkit import auth
 from hopeit.dataobjects.jsonify import Json
-from hopeit.app.context import EventContext, PostprocessHook, PreprocessHook
+from hopeit.app.context import EventContext, NoopMultiparReader, PostprocessHook, PreprocessHook
 from hopeit.dataobjects import DataObject, EventPayloadType
 from hopeit.app.errors import Unauthorized, BadRequest
 from hopeit.server.engine import Server, AppEngine
@@ -534,7 +534,7 @@ async def _handle_post_invocation(
         query_args = dict(request.query)
         _validate_authorization(app_engine.app_config, context, auth_types, request)
         payload = await _request_process_payload(context, datatype, request)
-        hook = PreprocessHook(headers=request.headers)
+        hook: PreprocessHook[NoopMultiparReader] = PreprocessHook(headers=request.headers)
         return await _request_execute(impl, event_name, context, query_args, payload, preprocess_hook=hook)
     except Unauthorized as e:
         return _ignored_response(context, 401, e)
@@ -561,7 +561,7 @@ async def _handle_get_invocation(
         payload = query_args.get('payload')
         if payload is not None:
             del query_args['payload']
-        hook = PreprocessHook(headers=request.headers)
+        hook: PreprocessHook[NoopMultiparReader] = PreprocessHook(headers=request.headers)
         return await _request_execute(impl, event_name, context, query_args, payload=payload,
                                       preprocess_hook=hook)
     except Unauthorized as e:
@@ -587,7 +587,9 @@ async def _handle_multipart_invocation(
         context = _request_start(app_engine, impl, event_name, request)
         query_args = dict(request.query)
         _validate_authorization(app_engine.app_config, context, auth_types, request)
-        hook = PreprocessHook(headers=request.headers, multipart_reader=await request.multipart())
+        hook = PreprocessHook(
+            headers=request.headers, multipart_reader=await request.multipart()  # type: ignore
+        )
         return await _request_execute(impl, event_name, context, query_args, payload=None,
                                       preprocess_hook=hook)
     except Unauthorized as e:


### PR DESCRIPTION
Fixes #62 

MOTIVATION:
==========
Since the introduction of PreprocessHook for multipart reading HTTP requests,
import EventContext withouth installing web dependencies was impossible.

SOLUTION:
=========
This PR removes dependency from context.py module to aiohttp by creating a Protocol for MultipartReader
and BodyPartReader. So EventContext, PreprocessHook can be imported i.e. from Jupyter notebooks or 
applications without the need of aiohttp when web server is not needed.
