### PR TITLE
fix(engine)): Fix queue propagation on steps stage splits (SHUFFLE step)

### DIFF
--- a/engine/src/hopeit/server/steps.py
+++ b/engine/src/hopeit/server/steps.py
@@ -267,6 +267,7 @@ def split_event_stages(app: AppDescriptor,
     effective_events: Dict[str, EventDescriptor] = {}
     event_type = event_info.type
     read_stream = event_info.read_stream
+    queues = ["AUTO"] if read_stream is None else read_stream.queues
     sub_event_name: Optional[str] = event_name
     sub_event_info = event_info
     intermediate_stream = None
@@ -276,7 +277,8 @@ def split_event_stages(app: AppDescriptor,
         if read_stream is None and intermediate_stream is not None:
             read_stream = ReadStreamDescriptor(
                 name=intermediate_stream,
-                consumer_group=auto_path(app.name, app.version, *event_name.split('.'), stage)
+                consumer_group=auto_path(app.name, app.version, *event_name.split('.'), stage),
+                queues=queues
             )
         intermediate_stream = auto_path(app.name, app.version, *event_name.split('.'), stage)
         sub_event_info = EventDescriptor(

--- a/engine/test/unit/server/test_steps.py
+++ b/engine/test/unit/server/test_steps.py
@@ -299,7 +299,7 @@ def test_split_event_stages_queues(mock_app_config):  # noqa: F811
             read_stream=ReadStreamDescriptor(
                 name='mock_app.test.mock_shuffle_event.produce_messages',
                 consumer_group='mock_app.test.mock_shuffle_event.consume_stream',
-                queues=['AUTO']
+                queues=["q1", "q2"]
             ),
             write_stream=event_info.write_stream,
             config=event_config,


### PR DESCRIPTION
BUG: 
====
when splitting events with SHUFFLE step an intermediate stream is generated. This stream was missing the list of queus to read in case original event is not using default ["AUTO"] queue.

FIX:
===
Ensure generated intermediate streams contains queues equal to the original queues in read_stream of split event.
