### PR TITLE
fix(openapi): date and datetime types handled in query string parameters

### DIFF
--- a/apps/examples/simple-example/src/simple_example/download_something.py
+++ b/apps/examples/simple-example/src/simple_example/download_something.py
@@ -38,9 +38,12 @@ async def find_image(payload: None, context: EventContext, *, file_name: str) ->
     """
     Find image file
     """
-    src_file_path = "./apps/examples/simple-example/resources/hopeit-iso.png"
+    src_file_path = f"./apps/examples/simple-example/resources/{file_name}"
     tgt_file_path = os.path.join(str(context.env['fs']['data_path']), file_name)
-    shutil.copy(src_file_path, tgt_file_path)
+    try:
+        shutil.copy(src_file_path, tgt_file_path)
+    except IOError as msg:
+        print(f"Unable to copy file. {msg}")
 
     return ImagePng(file_name=file_name, file_path=tgt_file_path)
 

--- a/apps/examples/simple-example/test/integration/test_it_download_something.py
+++ b/apps/examples/simple-example/test/integration/test_it_download_something.py
@@ -9,7 +9,7 @@ APP_VERSION = APPS_API_VERSION.replace('.', "x")
 @pytest.mark.asyncio
 async def test_it_download_something(app_config):
 
-    file_name = "hopeit.png"
+    file_name = "hopeit-iso.png"
 
     result, pp_result, response = await execute_event(
         app_config=app_config,

--- a/apps/examples/simple-example/test/integration/test_it_download_something_not_found.py
+++ b/apps/examples/simple-example/test/integration/test_it_download_something_not_found.py
@@ -1,0 +1,23 @@
+import pytest  # type: ignore
+
+from hopeit.testing.apps import execute_event
+from hopeit.server.version import APPS_API_VERSION
+
+APP_VERSION = APPS_API_VERSION.replace('.', "x")
+
+
+@pytest.mark.asyncio
+async def test_it_download_something_not_found(app_config):
+
+    file_name = "not_found.png"
+
+    _, pp_result, response = await execute_event(
+        app_config=app_config,
+        event_name='download_something',
+        payload=None,
+        postprocess=True,
+        file_name=file_name
+    )
+
+    assert pp_result == f"File {file_name} not found"
+    assert response.status == 400

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+Version 0.4.2
+_____________
+- FIX: `date` and `datetime` types are handled according to OpenAPI specs in query string parameters. This is not a breaking change but consider checking that for existing date/datetime query args value format will be validated at request time starting this version.
+
+
+Version 0.4.1
+_____________
+- FIX: Missing template on app-visualizer
+
 
 Version 0.4.1
 _____________

--- a/engine/src/hopeit/server/api.py
+++ b/engine/src/hopeit/server/api.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from typing import Dict, List, Tuple, Type, Optional, Callable, Awaitable, Union
+from datetime import date, datetime
 
 from aiohttp import web
 from aiohttp_swagger3 import RapiDocUiSettings  # type: ignore
@@ -683,8 +684,10 @@ TYPE_MAPPERS = {
 }
 
 BUILTIN_TYPES = {
-    str: 'string',
-    int: 'integer',
-    float: 'number',
-    bool: 'boolean'
+    str: ('string', None),
+    int: ('integer', None),
+    float: ('number', None),
+    bool: ('boolean', None),
+    date: ('string', 'date'),
+    datetime: ('string', 'date-time')
 }

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.4.1"
+ENGINE_VERSION = "0.4.2"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/test/mock_app/__init__.py
+++ b/engine/test/mock_app/__init__.py
@@ -246,6 +246,10 @@ def mock_api_app_config():
                 type=EventType.GET,
                 auth=[AuthType.REFRESH]
             ),
+            "mock-app-api-query-args": EventDescriptor(
+                type=EventType.GET,
+                auth=[AuthType.REFRESH]
+            ),
             "mock-app-noapi": EventDescriptor(
                 type=EventType.GET
             ),
@@ -532,6 +536,75 @@ def mock_api_spec():
                         'name': 'arg1',
                         'required': False,
                         'schema': {'type': 'integer'}
+                    }, {
+                        'description': 'Track information: Request-Id',
+                        'in': 'header',
+                        'name': 'X-Track-Request-Id',
+                        'required': False,
+                        'schema': {'type': 'string'}
+                    }, {'description': 'Track information: Request-Ts',
+                        'in': 'header',
+                        'name': 'X-Track-Request-Ts',
+                        'required': False,
+                        'schema': {
+                            'format': 'date-time',
+                            'type': 'string'}
+                        }, {
+                        'description': 'Track information: track.session_id',
+                        'in': 'header',
+                        'name': 'X-Track-Session-Id',
+                        'required': True,
+                        'schema': {
+                            'default': 'test.session_id',
+                            'type': 'string'}
+                    }], 'responses': {
+                        '200': {
+                            'content': {
+                                'application/json': {
+                                    'schema': {
+                                        'items': {'$ref': '#/components/schemas/MockData'},
+                                        'type': 'array'}}
+                            }, 'description': 'MockData result'
+                        }
+                    },
+                    'security': [{'mock_app_api.test.refresh': []}],
+                    'tags': ['mock_app_api.test']
+                }
+            },
+            '/api/mock-app-api/test/mock-app-api-query-args': {
+                'get': {
+                    'summary': 'Test app api query args',
+                    'description': 'Description of Test app queryargs',
+                    'parameters': [{
+                        'description': 'str argument',
+                        'in': 'query',
+                        'name': 'arg_str',
+                        'required': False,
+                        'schema': {'type': 'string'}
+                    }, {
+                        'name': 'arg_int',
+                        'in': 'query',
+                        'required': False,
+                        'description': 'int argument',
+                        'schema': {'type': 'integer'}
+                    }, {
+                        'name': 'arg_float',
+                        'in': 'query',
+                        'required': False,
+                        'description': 'float argument',
+                        'schema': {'type': 'number'}
+                    }, {
+                        'name': 'arg_date',
+                        'in': 'query',
+                        'required': False,
+                        'description': 'date argument',
+                        'schema': {'type': 'string', 'format': 'date'}
+                    }, {
+                        'name': 'arg_datetime',
+                        'in': 'query',
+                        'required': False,
+                        'description': 'datetime argument',
+                        'schema': {'type': 'string', 'format': 'date-time'}
                     }, {
                         'description': 'Track information: Request-Id',
                         'in': 'header',

--- a/engine/test/mock_app/mock_app_api_get_list.py
+++ b/engine/test/mock_app/mock_app_api_get_list.py
@@ -4,7 +4,6 @@ NO TITLE HERE, Title in __api__
 Description of Test app api list
 """
 from typing import Optional, List
-
 from hopeit.app.api import event_api
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.context import EventContext
@@ -23,6 +22,6 @@ __api__ = event_api(
 )
 
 
-def entry_point(payload: None, context: EventContext, arg1: Optional[int] = None) -> List[MockData]:
+def entry_point(payload: None, context: EventContext, *, arg1: Optional[int] = None) -> List[MockData]:
     logger.info(context, "mock_app_api_get_list.entry_point")
     return [MockData(f"get-{arg1}")]

--- a/engine/test/mock_app/mock_app_api_query_args.py
+++ b/engine/test/mock_app/mock_app_api_query_args.py
@@ -1,0 +1,39 @@
+"""
+Test app api query args
+
+Description of Test app queryargs
+"""
+from typing import Optional, List
+from datetime import datetime, date
+from hopeit.app.api import event_api
+from hopeit.app.logger import app_extra_logger
+from hopeit.app.context import EventContext
+from mock_app import MockData
+
+logger, extra = app_extra_logger()
+
+__steps__ = ['entry_point']
+
+__api__ = event_api(
+    summary="Test app api query args",
+    description="Description of Test app queryargs",
+    query_args=[('arg_str', Optional[str], "str argument"),
+                ('arg_int', Optional[int], "int argument"),
+                ('arg_float', Optional[float], "float argument"),
+                ('arg_date', Optional[date], "date argument"),
+                ('arg_datetime', Optional[datetime], "datetime argument")],
+    responses={
+        200: (List[MockData], "MockData result")
+    }
+)
+
+
+def entry_point(payload: None, context: EventContext,
+                *, arg_str: Optional[str] = None,
+                arg_int: Optional[int] = None,
+                arg_float: Optional[float] = None,
+                arg_date: Optional[date] = None,
+                arg_datetime: Optional[datetime] = None) -> List[MockData]:
+
+    logger.info(context, "mock_app_api_query_args.entry_point")
+    return [MockData(f"get-{arg_str} get-{arg_int}, get-{arg_float}, get-{arg_date}, get{arg_datetime}")]


### PR DESCRIPTION
**FIX:  `date` and `datetime` types handling in query string parameters** :
Types support added:
- `date`
- `datetime`

When you create an openapi definition and set a query param as `datetime` type:
```
__api__ = event_api(
    query_args=[('query_at', Optional[datetime], 'Overwrite query date')],
    responses={
        200: (Job, "Job Info")
    }
)

```
API spec BEFORE:
```
..
"parameters": [
          {
            "name": "query_at'",
            "in": "query",
            "required": false,
            "description": "Overwrite query date",
            "schema": {
              "type": "string"
            }
          },..
```

API spec NOW:
```
"parameters": [
          {
            "name": "query_at'",
            "in": "query",
            "required": false,
            "description": "Overwrite query date",
            "schema": {
              "type": "string",
              "format": "date-time"
            }
          },
```

**NOTE:**
When using a definition of `date` or `datetime` in query string parameters of the API specs now `hopeit.engine` will validate the data types as expected in OpenAPI:

- `date` full-date notation as defined by [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6), for example, 2017-07-21
- `datetime` – the date-time notation as defined by [RFC 3339, section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6), for example, 2017-07-21T17:32:28Z

