### PR TITLE
fix(apps) Fixed simple-example version to match engine

### DIFF
--- a/apps/examples/simple-example/setup.py
+++ b/apps/examples/simple-example/setup.py
@@ -1,9 +1,13 @@
 import setuptools
 
 
+version = {}
+with open("../../../engine/src/hopeit/server/version.py") as fp:
+    exec(fp.read(), version)
+
 setuptools.setup(
     name="simple_example",
-    version="0.3.0",
+    version=version['ENGINE_VERSION'],
     description="Hopeit.py Example App",
     package_dir={
         "": "src"

--- a/plugins/auth/basic-auth/setup.py
+++ b/plugins/auth/basic-auth/setup.py
@@ -1,9 +1,13 @@
 import setuptools
 
 
+version = {}
+with open("../../../engine/src/hopeit/server/version.py") as fp:
+    exec(fp.read(), version)
+
 setuptools.setup(
     name="hopeit.plugins.basic_auth",
-    version="0.2.0",
+    version=version['ENGINE_VERSION'],
     description="Hopeit.py Basic Auth Plugin",
     package_dir={
         "": "src"


### PR DESCRIPTION
Matching simple-example version to engine version.

NOTE:
=====
This change does not need a release, since simple-example is not released in PyPi,
this only affects mostly developers running simple-example locally.
