### PR TITLE
plugin(config-manager): Added config manager client

### DIFF
--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1705,7 +1705,7 @@
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "RuntimeAppInfo(servers: List[hopeit.config_manager.ServerInfo], app_config: hopeit.app.config.AppConfig)"
+        "description": "\n    Application config information associated to servers at runtime\n    "
       },
       "ServerInfo": {
         "type": "object",
@@ -1726,7 +1726,7 @@
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "ServerInfo(host_name: str, pid: str, url: str = 'in-process')"
+        "description": "\n    Server info associated with runtime apps\n    "
       },
       "AppConfig": {
         "type": "object",
@@ -2292,7 +2292,7 @@
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "RuntimeApps(apps: Dict[str, hopeit.config_manager.RuntimeAppInfo], server_status: Dict[str, hopeit.config_manager.ServerStatus] = <factory>)"
+        "description": "\n    Combined App Config and Server Sttus information for running apps\n    "
       },
       "VisualizationOptions": {
         "type": "object",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2168,7 +2168,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.7.0"
+            "default": "0.7.1"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -2276,10 +2276,23 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/RuntimeAppInfo"
             }
+          },
+          "server_status": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "ALIVE",
+                "ERROR"
+              ],
+              "x-enum-name": "ServerStatus",
+              "x-module-name": "hopeit.config_manager"
+            },
+            "default": {}
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "RuntimeApps(apps: Dict[str, hopeit.config_manager.RuntimeAppInfo])"
+        "description": "RuntimeApps(apps: Dict[str, hopeit.config_manager.RuntimeAppInfo], server_status: Dict[str, hopeit.config_manager.ServerStatus] = <factory>)"
       },
       "VisualizationOptions": {
         "type": "object",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,11 @@ Release Notes
 =============
 
 
+Version 0.7.1
+_____________
+- Config Manager Plugin: Moved cluster_apps_config logic to client that can be used from other apps or plugins.
+
+
 Version 0.7.0
 _____________
 - Config Manager Plugin: allows remote access to runtime configuration for `hopeit.engine` servers and clusters

--- a/engine/src/hopeit/server/logger.py
+++ b/engine/src/hopeit/server/logger.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime
 from functools import partial
 from logging.handlers import WatchedFileHandler
-from typing import Dict, Iterable, Union, List, Any
+from typing import Dict, Iterable, Union, List, Tuple, Callable, Any
 from stringcase import snakecase  # type: ignore
 
 import hopeit.server.version as version
@@ -267,13 +267,33 @@ def setup_app_logger(module, *, app_config: AppConfig, name: str, event_info: Ev
 def engine_logger() -> EngineLoggerWrapper:
     """
     Returns logger wrapper for engine modules
-    Allows to reference `logger` as a module variable.
+    Allows to reference `logger` at module scope.
 
     Use at module level in events implementation::
-
+    ```
         from hopeit.logger import engine_logger()
 
         logger = engine_logger()
-
+    ```
     """
     return EngineLoggerWrapper()
+
+
+def engine_extra_logger() -> Tuple[EngineLoggerWrapper, Callable]:
+    """
+    Returns logger wrapper for engine modules
+    and a convenience function to submit extra values when logging.
+    Allows to reference `logger` and `extra` at module scope.
+
+    Use at module level in events implementation::
+    ```
+        from hopeit.logger import engine_logger()
+
+        logger, extra = engine_extra_logger()
+
+        ...
+        
+        logger.info(context, "message" extra=extra(value1="extra_value", ...))
+    ```
+    """
+    return EngineLoggerWrapper(), partial(extra_values, [])

--- a/engine/src/hopeit/server/logger.py
+++ b/engine/src/hopeit/server/logger.py
@@ -292,7 +292,7 @@ def engine_extra_logger() -> Tuple[EngineLoggerWrapper, Callable]:
         logger, extra = engine_extra_logger()
 
         ...
-        
+
         logger.info(context, "message" extra=extra(value1="extra_value", ...))
     ```
     """

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -12,12 +12,16 @@ ENGINE_VERSION = "0.7.0"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])
+APPS_ROUTE_VERSION = APPS_API_VERSION.replace('.', 'x')
 
 os.environ['HOPEIT_ENGINE_VERSION'] = ENGINE_VERSION
 os.environ['HOPEIT_APPS_API_VERSION'] = APPS_API_VERSION
+os.environ['HOPEIT_APPS_ROUTE_VERSION'] = APPS_ROUTE_VERSION
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "APPS_API_VERSION":
         print(APPS_API_VERSION)
+    elif len(sys.argv) > 1 and sys.argv[1] == "APPS_ROUTE_VERSION":
+        print(APPS_ROUTE_VERSION)
     else:
         print(ENGINE_VERSION)

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.7.0"
+ENGINE_VERSION = "0.7.1"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
@@ -12,6 +12,9 @@ from hopeit.app.config import AppConfig
 @dataobject
 @dataclass
 class ServerInfo:
+    """
+    Server info associated with runtime apps
+    """
     host_name: str
     pid: str
     url: str = "in-process"
@@ -25,6 +28,9 @@ class ServerStatus(Enum):
 @dataobject
 @dataclass
 class RuntimeAppInfo:
+    """
+    Application config information associated to servers at runtime
+    """
     servers: List[ServerInfo]
     app_config: AppConfig
 
@@ -32,5 +38,8 @@ class RuntimeAppInfo:
 @dataobject
 @dataclass
 class RuntimeApps:
+    """
+    Combined App Config and Server Sttus information for running apps
+    """
     apps: Dict[str, RuntimeAppInfo]
     server_status: Dict[str, ServerStatus] = field(default_factory=dict)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
@@ -2,8 +2,10 @@
 Config Manager dataclasses
 """
 from typing import Dict, List
+from enum import Enum
+from dataclasses import dataclass, field
 
-from hopeit.dataobjects import dataclass, dataobject
+from hopeit.dataobjects import dataobject
 from hopeit.app.config import AppConfig
 
 
@@ -13,6 +15,11 @@ class ServerInfo:
     host_name: str
     pid: str
     url: str = "in-process"
+
+
+class ServerStatus(Enum):
+    ALIVE = "ALIVE"
+    ERROR = "ERROR"
 
 
 @dataobject
@@ -26,3 +33,4 @@ class RuntimeAppInfo:
 @dataclass
 class RuntimeApps:
     apps: Dict[str, RuntimeAppInfo]
+    server_status: Dict[str, ServerStatus] = field(default_factory=dict)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/client.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/client.py
@@ -1,0 +1,67 @@
+"""
+Config Manager Client
+"""
+from typing import Dict
+import asyncio
+import random
+
+import aiohttp
+
+from hopeit.server.version import APPS_ROUTE_VERSION
+from hopeit.app.context import EventContext
+from hopeit.app.logger import app_extra_logger
+
+from hopeit.config_manager import RuntimeApps, RuntimeAppInfo
+
+logger, extra = app_extra_logger()
+
+
+async def get_apps_config(hosts: str, context: EventContext) -> RuntimeApps:
+    """
+    Gathers RuntimeApps (runtime apps config) from a given list of hosts running
+    `hopeit.config-manager` plugins and returns a combined RuntimeApps
+    specifiying for each app_key its configuration and description of hosts where
+    it is avalable.
+
+    :param: hosts, str: comma-separated list of the form `http://host:port` where to reach
+        servers running hopeit.engine with enabled `config-manager` plugin.
+    :return: RuntimeApps, combined from all requested hosts
+    """
+    runtime_configs = await asyncio.gather(
+        *[
+            _get_host_config(host, context)
+            for host in hosts.split(',')
+        ]
+    )
+
+    logger.info("Gather hosts config done.")
+    apps: Dict[str, RuntimeAppInfo] = {}
+    for runtime_apps in runtime_configs:
+        _combine_apps(apps, runtime_apps)
+
+    return RuntimeApps(apps=apps)
+
+
+async def _get_host_config(host: str, context: EventContext) -> RuntimeApps:
+    """
+    Invokes config-manager runtime-apps-config endpoint in a given host
+    """
+    # Random <1 sec pause to prevent network overload
+    await asyncio.sleep(random.random())
+
+    url = f"{host}/api/config-manager/{APPS_ROUTE_VERSION}/runtime-apps-config?url={host}"
+    logger.info(context, "Invoking config-manager on host: {host}...", extra=extra(
+        host=host, url=url
+    ))
+    async with aiohttp.ClientSession() as client:
+        async with client.get(url) as response:
+            return RuntimeApps.from_dict(await response.json())  # type: ignore
+
+
+def _combine_apps(apps: Dict[str, RuntimeAppInfo], runtime_apps: RuntimeApps):
+    for app_key, app_info in runtime_apps.apps.items():
+        app = apps.get(app_key)
+        if app is None:
+            apps[app_key] = app_info
+        else:
+            apps[app_key].servers.extend(app_info.servers)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/client.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/client.py
@@ -39,7 +39,7 @@ async def get_apps_config(hosts: str, context: Optional[EventContext] = None) ->
     for host, runtime_apps_response in responses:
         if isinstance(runtime_apps_response, RuntimeApps):
             _combine_apps(apps, runtime_apps_response)
-            server_status[host] = ServerStatus.ALIVE
+            server_status[host] = runtime_apps_response.server_status.get(host, ServerStatus.ALIVE)
         elif isinstance(runtime_apps_response, ServerStatus):
             server_status[host] = runtime_apps_response
 

--- a/plugins/ops/config-manager/src/hopeit/config_manager/client.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/client.py
@@ -1,7 +1,7 @@
 """
 Config Manager Client
 """
-from typing import Dict
+from typing import Dict, Union, Tuple, Optional
 import asyncio
 import random
 
@@ -9,14 +9,14 @@ import aiohttp
 
 from hopeit.server.version import APPS_ROUTE_VERSION
 from hopeit.app.context import EventContext
-from hopeit.app.logger import app_extra_logger
+from hopeit.server.logger import engine_extra_logger
 
-from hopeit.config_manager import RuntimeApps, RuntimeAppInfo
+from hopeit.config_manager import RuntimeApps, RuntimeAppInfo, ServerStatus
 
-logger, extra = app_extra_logger()
+logger, extra = engine_extra_logger()
 
 
-async def get_apps_config(hosts: str, context: EventContext) -> RuntimeApps:
+async def get_apps_config(hosts: str, context: Optional[EventContext] = None) -> RuntimeApps:
     """
     Gathers RuntimeApps (runtime apps config) from a given list of hosts running
     `hopeit.config-manager` plugins and returns a combined RuntimeApps
@@ -27,22 +27,28 @@ async def get_apps_config(hosts: str, context: EventContext) -> RuntimeApps:
         servers running hopeit.engine with enabled `config-manager` plugin.
     :return: RuntimeApps, combined from all requested hosts
     """
-    runtime_configs = await asyncio.gather(
+    responses = await asyncio.gather(
         *[
             _get_host_config(host, context)
             for host in hosts.split(',')
         ]
     )
 
-    logger.info("Gather hosts config done.")
     apps: Dict[str, RuntimeAppInfo] = {}
-    for runtime_apps in runtime_configs:
-        _combine_apps(apps, runtime_apps)
+    server_status: Dict[str, ServerStatus] = {}
+    for host, runtime_apps_response in responses:
+        if isinstance(runtime_apps_response, RuntimeApps):
+            _combine_apps(apps, runtime_apps_response)
+            server_status[host] = ServerStatus.ALIVE
+        elif isinstance(runtime_apps_response, ServerStatus):
+            server_status[host] = runtime_apps_response
 
-    return RuntimeApps(apps=apps)
+    return RuntimeApps(apps=apps, server_status=server_status)
 
 
-async def _get_host_config(host: str, context: EventContext) -> RuntimeApps:
+async def _get_host_config(host: str,
+                           context: Optional[EventContext] = None
+                           ) -> Tuple[str, Union[RuntimeApps, ServerStatus]]:
     """
     Invokes config-manager runtime-apps-config endpoint in a given host
     """
@@ -50,12 +56,19 @@ async def _get_host_config(host: str, context: EventContext) -> RuntimeApps:
     await asyncio.sleep(random.random())
 
     url = f"{host}/api/config-manager/{APPS_ROUTE_VERSION}/runtime-apps-config?url={host}"
-    logger.info(context, "Invoking config-manager on host: {host}...", extra=extra(
+    logger.info(context or __name__, "Invoking config-manager on host: %s...", host, extra=extra(
         host=host, url=url
     ))
-    async with aiohttp.ClientSession() as client:
-        async with client.get(url) as response:
-            return RuntimeApps.from_dict(await response.json())  # type: ignore
+
+    try:
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url) as response:
+                return (host, RuntimeApps.from_dict(await response.json()))  # type: ignore
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(context or __name__, "Error contacting host: %s", host, extra=extra(
+            host=host, url=url, error=str(e)
+        ))
+        return (host, ServerStatus.ERROR)
 
 
 def _combine_apps(apps: Dict[str, RuntimeAppInfo], runtime_apps: RuntimeApps):

--- a/plugins/ops/config-manager/src/hopeit/config_manager/cluster_apps_config.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/cluster_apps_config.py
@@ -3,22 +3,15 @@ Cluster Apps Config
 ----------------------------------------------------------------------------------------
 Handle remote access to runtime configuration from a group of hosts running hopeit.engine
 """
-from typing import Dict
-import aiohttp
-
-from hopeit.server.version import APPS_API_VERSION
-
 from hopeit.app.context import EventContext
 from hopeit.app.logger import app_extra_logger
 from hopeit.app.api import event_api
 
-from hopeit.config_manager import RuntimeApps, RuntimeAppInfo
-
-API_VERSION = APPS_API_VERSION.replace('.', 'x')
+from hopeit.config_manager import RuntimeApps, client
 
 logger, extra = app_extra_logger()
 
-__steps__ = ['get_apps_config']
+__steps__ = ['get_hosts_apps_config']
 
 __api__ = event_api(
     summary="Config Manager: Cluster Apps Config",
@@ -30,26 +23,5 @@ __api__ = event_api(
 )
 
 
-async def get_apps_config(payload: None, context: EventContext, *, hosts: str) -> RuntimeApps:
-    apps: Dict[str, RuntimeAppInfo] = {}
-    for url in hosts.split(','):
-        runtime_apps = await _get_host_config(url)
-        _combine_apps(apps, runtime_apps)
-    return RuntimeApps(apps=apps)
-
-
-async def _get_host_config(host: str):
-    async with aiohttp.ClientSession() as client:
-        async with client.get(
-            f"{host}/api/config-manager/{API_VERSION}/runtime-apps-config?url={host}"
-        ) as response:
-            return RuntimeApps.from_dict(await response.json())  # type: ignore
-
-
-def _combine_apps(apps: Dict[str, RuntimeAppInfo], runtime_apps: RuntimeApps):
-    for app_key, app_info in runtime_apps.apps.items():
-        app = apps.get(app_key)
-        if app is None:
-            apps[app_key] = app_info
-        else:
-            apps[app_key].servers.extend(app_info.servers)
+async def get_hosts_apps_config(payload: None, context: EventContext, *, hosts: str) -> RuntimeApps:
+    return await client.get_apps_config(hosts, context)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/runtime_apps_config.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/runtime_apps_config.py
@@ -12,7 +12,7 @@ from hopeit.server.runtime import server
 from hopeit.app.context import EventContext
 from hopeit.app.logger import app_extra_logger
 
-from hopeit.config_manager import RuntimeApps, RuntimeAppInfo, ServerInfo
+from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
 from hopeit.app.api import event_api
 
 logger, extra = app_extra_logger()
@@ -41,5 +41,8 @@ async def get_apps_config(payload: None, context: EventContext, *, url: str = "i
                 app_config=app_engine.app_config
             )
             for app_key, app_engine in server.app_engines.items()
+        },
+        server_status={
+            url: ServerStatus.ALIVE
         }
     )

--- a/plugins/ops/config-manager/test/integration/__init__.py
+++ b/plugins/ops/config-manager/test/integration/__init__.py
@@ -53,7 +53,9 @@ class MockClientSession():
         return None
 
     def get(self, url: str) -> MockResponse:
-        return MockResponse(self.responses[url])
+        if url in self.responses:
+            return MockResponse(self.responses[url])
+        raise IOError("Test error")
 
 
 def mock_client(module, monkeypatch, server1_apps_response, server2_apps_response):

--- a/plugins/ops/config-manager/test/integration/__init__.py
+++ b/plugins/ops/config-manager/test/integration/__init__.py
@@ -1,11 +1,10 @@
 from typing import Dict
 
 from hopeit.app.config import AppConfig
-from hopeit.server.version import APPS_API_VERSION, ENGINE_VERSION  # noqa: F401
 
 from hopeit.config_manager import RuntimeApps
 
-APP_VERSION = APPS_API_VERSION.replace('.', 'x')
+from hopeit.server.version import APPS_ROUTE_VERSION
 
 
 class MockAppEngine:
@@ -55,3 +54,15 @@ class MockClientSession():
 
     def get(self, url: str) -> MockResponse:
         return MockResponse(self.responses[url])
+
+
+def mock_client(module, monkeypatch, server1_apps_response, server2_apps_response):
+    url_pattern = "{}/api/config-manager/{}/runtime-apps-config?url={}"
+    url1 = url_pattern.format("http://test-server1", APPS_ROUTE_VERSION, "http://test-server1")
+    url2 = url_pattern.format("http://test-server2", APPS_ROUTE_VERSION, "http://test-server2")
+    monkeypatch.setattr(module.aiohttp, 'ClientSession', MockClientSession.setup(
+        responses={
+            url1: server1_apps_response,
+            url2: server2_apps_response
+        }
+    ))

--- a/plugins/ops/config-manager/test/integration/conftest.py
+++ b/plugins/ops/config-manager/test/integration/conftest.py
@@ -5,13 +5,13 @@ from hopeit.config_manager import RuntimeApps
 import socket
 import os
 
-from . import ENGINE_VERSION, APPS_API_VERSION, APP_VERSION
+from hopeit.server.version import APPS_API_VERSION, ENGINE_VERSION, APPS_ROUTE_VERSION
 
 
 RUNTIME_SIMPLE_EXAMPLE = """
 {
   "apps": {
-    "simple_example.${APP_VERSION}": {
+    "simple_example.${APPS_ROUTE_VERSION}": {
       "servers": [
         {
           "host_name": "${HOST_NAME}",
@@ -42,10 +42,10 @@ RUNTIME_SIMPLE_EXAMPLE = """
         },
         "env": {
           "fs": {
-            "data_path": "/tmp/simple_example.${APP_VERSION}.fs.data_path/"
+            "data_path": "/tmp/simple_example.${APPS_ROUTE_VERSION}.fs.data_path/"
           },
           "upload_something": {
-            "save_path": "/tmp/simple_example.${APP_VERSION}.upload_something.save_path/",
+            "save_path": "/tmp/simple_example.${APPS_ROUTE_VERSION}.upload_something.save_path/",
             "chunk_size": 16384
           }
         },
@@ -206,7 +206,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "SERVICE",
             "plug_mode": "Standalone",
             "write_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
                 "AUTO"
               ],
@@ -238,7 +238,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "POST",
             "plug_mode": "Standalone",
             "write_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
                 "high-prio"
               ],
@@ -272,8 +272,8 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "STREAM",
             "plug_mode": "Standalone",
             "read_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
-              "consumer_group": "simple_example.${APP_VERSION}.streams.process_events",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+              "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
               "queues": [
                 "high-prio",
                 "AUTO"
@@ -336,7 +336,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "POST",
             "plug_mode": "Standalone",
             "write_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
                 "AUTO"
               ],
@@ -370,7 +370,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "POST",
             "plug_mode": "Standalone",
             "write_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
                 "AUTO"
               ],
@@ -404,7 +404,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "POST",
             "plug_mode": "Standalone",
             "write_stream": {
-              "name": "simple_example.${APP_VERSION}.streams.something_event",
+              "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
                 "AUTO"
               ],
@@ -478,7 +478,7 @@ def _get_runtime_simple_example(url: str):
     res = res.replace("${URL}", url)
     res = res.replace("${ENGINE_VERSION}", ENGINE_VERSION)
     res = res.replace("${APPS_API_VERSION}", APPS_API_VERSION)
-    res = res.replace("${APP_VERSION}", APP_VERSION)
+    res = res.replace("${APPS_ROUTE_VERSION}", APPS_ROUTE_VERSION)
 
     return Json.from_json(res, RuntimeApps)
 
@@ -503,8 +503,8 @@ def cluster_apps_response():
     server1 = _get_runtime_simple_example("http://test-server1")
     server2 = _get_runtime_simple_example("http://test-server2")
 
-    server1.apps[f"simple_example.{APP_VERSION}"].servers.extend(
-        server2.apps[f"simple_example.{APP_VERSION}"].servers
+    server1.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers.extend(
+        server2.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers
     )
 
     return server1

--- a/plugins/ops/config-manager/test/integration/conftest.py
+++ b/plugins/ops/config-manager/test/integration/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hopeit.dataobjects.jsonify import Json
-from hopeit.config_manager import RuntimeApps
+from hopeit.config_manager import RuntimeApps, ServerStatus
 import socket
 import os
 
@@ -466,6 +466,9 @@ RUNTIME_SIMPLE_EXAMPLE = """
         ]
       }
     }
+  },
+  "server_status": {
+    "${URL}": "ALIVE"
   }
 }
 """
@@ -506,5 +509,6 @@ def cluster_apps_response():
     server1.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers.extend(
         server2.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers
     )
+    server1.server_status["http://test-server2"] = ServerStatus.ALIVE
 
     return server1

--- a/plugins/ops/config-manager/test/integration/test_client.py
+++ b/plugins/ops/config-manager/test/integration/test_client.py
@@ -1,0 +1,20 @@
+import pytest
+
+from hopeit.testing.apps import config, create_test_context
+
+from hopeit.config_manager import client
+
+from . import mock_client
+
+
+@pytest.mark.asyncio
+async def test_client(monkeypatch, cluster_apps_response,
+                      server1_apps_response, server2_apps_response):
+
+    mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
+
+    plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
+    context = create_test_context(plugin_config, "cluster-apps-config")
+    result = await client.get_apps_config("http://test-server1,http://test-server2", context)
+
+    assert result == cluster_apps_response

--- a/plugins/ops/config-manager/test/integration/test_client.py
+++ b/plugins/ops/config-manager/test/integration/test_client.py
@@ -1,8 +1,6 @@
 import pytest
 
-from hopeit.testing.apps import config, create_test_context
-
-from hopeit.config_manager import client
+from hopeit.config_manager import ServerStatus, client
 
 from . import mock_client
 
@@ -13,8 +11,24 @@ async def test_client(monkeypatch, cluster_apps_response,
 
     mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
 
-    plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
-    context = create_test_context(plugin_config, "cluster-apps-config")
-    result = await client.get_apps_config("http://test-server1,http://test-server2", context)
+    result = await client.get_apps_config("http://test-server1,http://test-server2")
 
     assert result == cluster_apps_response
+
+
+@pytest.mark.asyncio
+async def test_client_ignore_hosts_errors(monkeypatch, cluster_apps_response,
+                                          server1_apps_response, server2_apps_response):
+
+    mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
+
+    result = await client.get_apps_config(
+        "http://test-server1,http://test-server2,http://test-server-error"
+    )
+
+    assert result.apps == cluster_apps_response.apps
+    assert result.server_status == {
+        "http://test-server1": ServerStatus.ALIVE,
+        "http://test-server2": ServerStatus.ALIVE,
+        "http://test-server-error": ServerStatus.ERROR,
+    }

--- a/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
+++ b/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
@@ -1,36 +1,21 @@
 import pytest
 
-from hopeit.server import runtime
 from hopeit.testing.apps import config, execute_event
 
-from . import MockServer, MockClientSession, APP_VERSION
+from . import mock_client
 
 
 @pytest.mark.asyncio
 async def test_cluster_apps_config(monkeypatch, cluster_apps_response,
                                    server1_apps_response, server2_apps_response):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
 
-    def mock_client(module, context):
-        url_pattern = "{}/api/config-manager/{}/runtime-apps-config?url={}"
-        url1 = url_pattern.format("http://test-server1", APP_VERSION, "http://test-server1")
-        url2 = url_pattern.format("http://test-server2", APP_VERSION, "http://test-server2")
-        monkeypatch.setattr(module.aiohttp, 'ClientSession', MockClientSession.setup(
-            responses={
-                url1: server1_apps_response,
-                url2: server2_apps_response
-            }
-        ))
+    def apply_mock_client(module, context):
+        mock_client(module.client, monkeypatch, server1_apps_response, server2_apps_response)
 
     plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
     result = await execute_event(
         app_config=plugin_config, event_name="cluster-apps-config", payload=None,
-        mocks=[mock_client], hosts="http://test-server1,http://test-server2"
+        mocks=[apply_mock_client], hosts="http://test-server1,http://test-server2"
     )
 
     assert result == cluster_apps_response


### PR DESCRIPTION
Added config-manager client that can be used later from apps-visualizer to retrieve configuration from multiple hosts.

This PR only setups the client in config-manager plugin,
it is not used yet from apps-visualizer.

### Try it out

Follow same steps as in #89 

now, when an unknown or irresponsive host is called, it will be reported in the response.