### PR TITLE
feature(plugin) Apps visualizer remote connection to config-manager plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,25 @@
             "args": [
                 "--port=8020",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
+                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
                 "--api-file=apps/examples/simple-example/api/openapi.json"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "apps-visualizer",
+            "type": "python",
+            "request": "launch",
+            "module": "hopeit.server.web",
+            "env": {
+                "HOPEIT_APPS_VISUALIZER_HOSTS": "http://localhost:8020,http://localhost:8021,http://localhost:8098,http://localhost:8099"
+            },
+            "args": [
+                "--port=8098",
+                "--start-streams",
+                "--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json",
+                "--api-file=plugins/ops/apps-visualizer/api/openapi.json"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"

--- a/Makefile
+++ b/Makefile
@@ -120,5 +120,19 @@ run-simple-example:
 	hopeit_server run \
 		--port=$(PORT) \
 		--start-streams \
-		--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json,apps/examples/simple-example/config/app-config.json \
+		--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json \
 		--api-file=apps/examples/simple-example/api/openapi.json
+
+run-apps-visualizer:
+	export HOPEIT_APPS_VISUALIZER_HOSTS=$(HOSTS) && \
+	hopeit_server run \
+		--port=$(PORT) \
+		--start-streams \
+		--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json \
+		--api-file=plugins/ops/apps-visualizer/api/openapi.json
+
+run-log-streamer:
+	hopeit_server run \
+		--port=$(PORT) \
+		--start-streams \
+		--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/log-streamer/config/plugin-config.json

--- a/apps/benchmark/simple-benchmark/api/openapi.json
+++ b/apps/benchmark/simple-benchmark/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.7",
+    "version": "0.8",
     "title": "Simple Benchmark",
     "description": "Simple Benchmark App"
   },
   "paths": {
-    "/api/simple-benchmark/0x7/give-me-something": {
+    "/api/simple-benchmark/0x8/give-me-something": {
       "get": {
         "summary": "Simple Benchamrck: Give me Something",
         "description": "Loads Something from disk",
@@ -53,11 +53,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x7"
+          "simple_benchmark.0x8"
         ]
       }
     },
-    "/api/simple-benchmark/0x7/query-something-fs": {
+    "/api/simple-benchmark/0x8/query-something-fs": {
       "get": {
         "summary": "Simple Benchamrck: Query Something",
         "description": "Loads Something from disk",
@@ -114,11 +114,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x7"
+          "simple_benchmark.0x8"
         ]
       }
     },
-    "/api/simple-benchmark/0x7/save-something-fs": {
+    "/api/simple-benchmark/0x8/save-something-fs": {
       "post": {
         "summary": "Simple Benchmark: Save Something",
         "description": "Creates and saves Something",
@@ -176,11 +176,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x7"
+          "simple_benchmark.0x8"
         ]
       }
     },
-    "/api/simple-benchmark/0x7/query-something-redis": {
+    "/api/simple-benchmark/0x8/query-something-redis": {
       "get": {
         "summary": "Simple Benchamrck: Query Something",
         "description": "Loads Something from disk",
@@ -237,11 +237,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x7"
+          "simple_benchmark.0x8"
         ]
       }
     },
-    "/api/simple-benchmark/0x7/save-something-redis": {
+    "/api/simple-benchmark/0x8/save-something-redis": {
       "post": {
         "summary": "Simple Benchmark: Save Something",
         "description": "Creates and saves Something",
@@ -299,7 +299,7 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x7"
+          "simple_benchmark.0x8"
         ]
       }
     }

--- a/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
+++ b/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-fs?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-fs?item_id=string"

--- a/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
+++ b/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
@@ -7,6 +7,6 @@ else
   host=localhost
 fi
 for i in {1..2000}; do
-  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/0x7/save-something-fs"
+  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/0x8/save-something-fs"
 done
 echo Done.

--- a/apps/examples/simple-example/api/create-openapi-file.sh
+++ b/apps/examples/simple-example/api/create-openapi-file.sh
@@ -4,5 +4,5 @@ hopeit_openapi create \
 --title="Simple Example" \
 --description="Simple Example" \
 --api-version="$(python -m hopeit.server.version APPS_API_VERSION)" \
---config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json,apps/examples/simple-example/config/app-config.json \
+--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json \
 --output-file=apps/examples/simple-example/api/openapi.json

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2094,7 +2094,7 @@
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "\n    Combined App Config and Server Sttus information for running apps\n    "
+        "description": "\n    Combined App Config and Server Status information for running apps\n    "
       },
       "User": {
         "type": "object",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.7",
+    "version": "0.8",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/basic-auth/0x7/decode": {
+    "/api/basic-auth/0x8/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.0x7"
+          "basic_auth.0x8"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/config-manager/0x7/runtime-apps-config": {
+    "/api/config-manager/0x8/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -100,11 +100,11 @@
           }
         },
         "tags": [
-          "config_manager.0x7"
+          "config_manager.0x8"
         ]
       }
     },
-    "/api/config-manager/0x7/cluster-apps-config": {
+    "/api/config-manager/0x8/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -151,209 +151,11 @@
           }
         },
         "tags": [
-          "config_manager.0x7"
+          "config_manager.0x8"
         ]
       }
     },
-    "/ops/apps-visualizer": {
-      "get": {
-        "summary": "App Visualizer: Site",
-        "description": "[Click here to open Events Graph](/ops/apps-visualizer)",
-        "parameters": [
-          {
-            "name": "app_prefix",
-            "in": "query",
-            "required": false,
-            "description": "app_key prefix to filter",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "expand_queues",
-            "in": "query",
-            "required": false,
-            "description": "if `true` shows each stream queue as a separated stream",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "live",
-            "in": "query",
-            "required": false,
-            "description": "if `true` enable live stats refreshing",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "X-Track-Request-Id",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Track-Request-Ts",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Ts",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "HTML page with Events Graph",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "site.main"
-                  ],
-                  "properties": {
-                    "site.main": {
-                      "type": "string"
-                    }
-                  },
-                  "description": "site.main string payload"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "apps_visualizer.0x7"
-        ]
-      }
-    },
-    "/api/apps-visualizer/0x7/apps/events-graph": {
-      "get": {
-        "summary": "App Visualizer: Events Graph Data",
-        "description": "App Visualizer: Events Graph Data",
-        "parameters": [
-          {
-            "name": "app_prefix",
-            "in": "query",
-            "required": false,
-            "description": "app_key prefix to filter",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "expand_queues",
-            "in": "query",
-            "required": false,
-            "description": "if `true` shows each stream queue as a separated stream",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "X-Track-Request-Id",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Track-Request-Ts",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Ts",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Graph Data with applied Live Stats",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventsGraphResult"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "apps_visualizer.0x7"
-        ]
-      }
-    },
-    "/api/apps-visualizer/0x7/event-stats/live": {
-      "get": {
-        "summary": "App Visualizer: Live Stats",
-        "description": "App Visualizer: Live Stats",
-        "parameters": [
-          {
-            "name": "app_prefix",
-            "in": "query",
-            "required": false,
-            "description": "app_key prefix to filter",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "expand_queues",
-            "in": "query",
-            "required": false,
-            "description": "if `true` shows each stream queue as a separated stream",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "X-Track-Request-Id",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Track-Request-Ts",
-            "in": "header",
-            "required": false,
-            "description": "Track information: Request-Ts",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Graph Data with applied Live Stats",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventsGraphResult"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "apps_visualizer.0x7"
-        ]
-      }
-    },
-    "/api/simple-example/0x7/list-somethings": {
+    "/api/simple-example/0x8/list-somethings": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -423,7 +225,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -432,7 +234,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/query-something": {
+    "/api/simple-example/0x8/query-something": {
       "get": {
         "summary": "Simple Example: Query Something",
         "description": "Loads Something from disk",
@@ -509,7 +311,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -604,7 +406,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -613,7 +415,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/save-something": {
+    "/api/simple-example/0x8/save-something": {
       "post": {
         "summary": "Simple Example: Save Something",
         "description": "Creates and saves Something",
@@ -710,7 +512,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -719,7 +521,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/download-something": {
+    "/api/simple-example/0x8/download-something": {
       "get": {
         "summary": "Simple Example: Download Something",
         "description": "Download image file. The PostprocessHook return the requested file as stream.",
@@ -806,7 +608,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -815,7 +617,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/upload-something": {
+    "/api/simple-example/0x8/upload-something": {
       "post": {
         "summary": "Simple Example: Multipart Upload files",
         "description": "Upload files using Multipart form request",
@@ -953,7 +755,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -962,7 +764,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/streams/something-event": {
+    "/api/simple-example/0x8/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
         "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
@@ -1031,7 +833,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1040,7 +842,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/collector/query-concurrently": {
+    "/api/simple-example/0x8/collector/query-concurrently": {
       "post": {
         "summary": "Simple Example: Query Concurrently",
         "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
@@ -1112,7 +914,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1121,7 +923,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/collector/collect-spawn": {
+    "/api/simple-example/0x8/collector/collect-spawn": {
       "post": {
         "summary": "Simple Example: Collect and Spawn",
         "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
@@ -1199,7 +1001,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1208,7 +1010,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/shuffle/spawn-event": {
+    "/api/simple-example/0x8/shuffle/spawn-event": {
       "post": {
         "summary": "Simple Example: Spawn Event",
         "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
@@ -1286,7 +1088,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1295,7 +1097,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/shuffle/parallelize-event": {
+    "/api/simple-example/0x8/shuffle/parallelize-event": {
       "post": {
         "summary": "Simple Example: Parallelize Event",
         "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
@@ -1373,7 +1175,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1382,7 +1184,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/basic-auth/0x7/login": {
+    "/api/simple-example/0x8/basic-auth/0x8/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -1450,7 +1252,7 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
@@ -1459,7 +1261,7 @@
         ]
       }
     },
-    "/api/simple-example/0x7/basic-auth/0x7/refresh": {
+    "/api/simple-example/0x8/basic-auth/0x8/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -1527,16 +1329,16 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
-            "simple_example.0x7.refresh": []
+            "simple_example.0x8.refresh": []
           }
         ]
       }
     },
-    "/api/simple-example/0x7/basic-auth/0x7/logout": {
+    "/api/simple-example/0x8/basic-auth/0x8/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -1613,11 +1415,11 @@
           }
         },
         "tags": [
-          "simple_example.0x7"
+          "simple_example.0x8"
         ],
         "security": [
           {
-            "simple_example.0x7.refresh": []
+            "simple_example.0x8.refresh": []
           }
         ]
       }
@@ -2168,7 +1970,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.7.1"
+            "default": "0.8.0"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -2293,42 +2095,6 @@
         },
         "x-module-name": "hopeit.config_manager",
         "description": "\n    Combined App Config and Server Sttus information for running apps\n    "
-      },
-      "VisualizationOptions": {
-        "type": "object",
-        "properties": {
-          "app_prefix": {
-            "type": "string",
-            "default": ""
-          },
-          "expand_queues": {
-            "type": "boolean",
-            "default": false
-          },
-          "live": {
-            "type": "boolean",
-            "default": false
-          }
-        },
-        "x-module-name": "hopeit.apps_visualizer.site.visualization",
-        "description": "VisualizationOptions(app_prefix: str = '', expand_queues: bool = False, live: bool = False)"
-      },
-      "EventsGraphResult": {
-        "type": "object",
-        "required": [
-          "runtime_apps",
-          "options"
-        ],
-        "properties": {
-          "runtime_apps": {
-            "$ref": "#/components/schemas/RuntimeApps"
-          },
-          "options": {
-            "$ref": "#/components/schemas/VisualizationOptions"
-          }
-        },
-        "x-module-name": "hopeit.apps_visualizer.site.main",
-        "description": "EventsGraphResult(runtime_apps: hopeit.apps_visualizer.site.main.RuntimeApps, options: hopeit.apps_visualizer.site.visualization.VisualizationOptions)"
       },
       "User": {
         "type": "object",
@@ -2461,10 +2227,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "simple_example.0x7.refresh": {
+      "simple_example.0x8.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "simple_example.0x7.refresh"
+        "name": "simple_example.0x8.refresh"
       }
     }
   },

--- a/docs/source/benchmark/dedicated.rst
+++ b/docs/source/benchmark/dedicated.rst
@@ -12,11 +12,11 @@ real time") for every request in the 99th percentile. The result is a rate (requ
 
 Three endpoints are evaluated in each test scenario
 
-* http://hostname:port/api/simple-benchmark/0x7/give-me-something retrieves information from objects randomly created
+* http://hostname:port/api/simple-benchmark/0x8/give-me-something retrieves information from objects randomly created
 
-* http://hostname:port/api/simple-benchmark/0x7/query-something-redis returns information from objects stored on a Redis server (memory store)
+* http://hostname:port/api/simple-benchmark/0x8/query-something-redis returns information from objects stored on a Redis server (memory store)
 
-* http://hostname:port/api/simple-benchmark/0x7/query-something-fs retrieves information from objects stored on a file system (SSD drive)
+* http://hostname:port/api/simple-benchmark/0x8/query-something-fs retrieves information from objects stored on a file system (SSD drive)
 
 Scenarios:
 __________
@@ -68,13 +68,13 @@ Now we are ready to start the simple-benchmark app to run the tests
 
 Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed starts into account) results:
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/give-me-something?item_id=string"
  p99 30.38ms @ 1794.29 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-redis?item_id=string"
  p99 27.18ms @ 1226.51 req/s
 
-./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-fs?item_id=string"
  p99 31.12ms @ 803.38 req/s
 
 2 . Docker, single/multiple instances of hopeit.engine
@@ -103,22 +103,22 @@ Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed sta
 
 4 hopeit.engine instances behind a reverse proxy
 
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/give-me-something?item_id=string"
  p99 27.77ms @ 2587.95 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-redis?item_id=string"
  p99 28.67ms @ 1810.14 req/s
 
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x7/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x8/query-something-fs?item_id=string"
  p99 30.29ms @ 1241.39 req/s
 
 1 hopeit.engine instance
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/give-me-something?item_id=string"
  p99 26.48ms @ 1336.18 req/s
 
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-redis?item_id=string"
  p99 29.14ms @ 908.93 req/s
 
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x7/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x8/query-something-fs?item_id=string"
  p99 24.77ms @ 624.77 req/s

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,19 @@ Release Notes
 =============
 
 
+Version 0.8.0
+_____________
+- Config Manager Plugin: added support to access current process configuration with special hostname "in-process"
+- Apps Visualizer plugin:
+  - Now can (and should) run separately from the apps/servers that is monitoring
+  - Supports connection to remote hosts running config-manager plugin
+  - Added list of hosts and status (ALIVE if reachable, ERROR if not)
+  - Filter config and live activity by host/group of hosts by name
+  - Automatic refresh servers/hosts status
+  - Automatic refresh list of active apps
+  - Automatic refresh graph on configuration or hosts availability changes
+
+
 Version 0.7.3
 _____________
 - Including type information in PIP packages for `hopeit.engine` and plugins.

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.7.3"
+ENGINE_VERSION = "0.8.0"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/build/ci-static-plugins.sh
+++ b/plugins/build/ci-static-plugins.sh
@@ -46,9 +46,9 @@ python3 -m pylint plugins/storage/fs/src/hopeit/fs_storage/
 code+=$?
 
 echo "ops/apps-visualizer"
-export MYPYPATH=engine/src/:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:plugins/ops/apps-visualizer/src/ && python3 -m mypy --namespace-packages -p hopeit.apps_visualizer
+export MYPYPATH=engine/src/:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:plugins/ops/config-manager/src/:plugins/ops/apps-visualizer/src/ && python3 -m mypy --namespace-packages -p hopeit.apps_visualizer
 code+=$?
-export MYPYPATH=engine/src/:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:plugins/ops/apps-visualizer/src/ && python3 -m mypy --namespace-packages plugins/ops/apps-visualizer/test/integration/
+export MYPYPATH=engine/src/:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:plugins/ops/config-manager/src/:plugins/ops/apps-visualizer/src/ && python3 -m mypy --namespace-packages plugins/ops/apps-visualizer/test/integration/
 code+=$?
 python3 -m flake8 --max-line-length=120 plugins/ops/apps-visualizer/src/hopeit/ plugins/ops/apps-visualizer/test/integration/
 code+=$?

--- a/plugins/build/ci-test-plugins.sh
+++ b/plugins/build/ci-test-plugins.sh
@@ -19,7 +19,7 @@ export PYTHONPATH=engine/src/:plugins/storage/fs/src/ && python3 -m pytest -v --
 code+=$?
 
 # ops/apps-visualizer
-export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:apps/examples/simple-example/src/:plugins/ops/apps-visualizer/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=plugins/ops/apps-visualizer/src/ plugins/ops/apps-visualizer/test/integration/
+export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:plugins/storage/fs/src/:plugins/ops/log-streamer/src/:plugins/ops/config-manager/src/:apps/examples/simple-example/src/:plugins/ops/apps-visualizer/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=plugins/ops/apps-visualizer/src/ plugins/ops/apps-visualizer/test/integration/
 code+=$?
 
 # ops/config-manager

--- a/plugins/ops/apps-visualizer/README.md
+++ b/plugins/ops/apps-visualizer/README.md
@@ -12,16 +12,31 @@ This library is part of hopeit.engine:
 pip install hopeit.engine[apps-visualizer]
 ```
 
-### Include plugin configuration file when running `hopeit_server` in addition to your existing config files.
+### Include config-manager plugin config file when running `hopeit_server` in addition to your existing config files for each process/server that needs to be monitored.
 
 ```
-hopeit_server ... --config-files=...,plugins/ops/apps-visualizer/config/plugin-config.json,...
+hopeit_server --port=8020 --config-files=server-config.json,plugins/ops/config-manager/config/plugin-config.json,my-app-config.json
 ```
+
+### Export list of hosts to connect to, and run a new hopeit_server instance with apps-visualizer plugin
+
+```
+export HOPEIT_APPS_VISUALIZER_HOSTS="http://host:8020,in-process"
+
+hopeit_server --port=8098 --config-files=server-config.json,plugins/ops/apps-visualizer/config/plugin-config.json --api-file=plugins/ops/apps-visualizer/api/openapi.json
+```
+
+> The first host in the list, specifies to monitor apps running in `http://host:8020` by connecting in intervals to the server through config-manager plugin endpoints.
+
+> Using `in-process` as host name local process running apps-visualizer can be monitored also without network load.
+
+> Instead of using an environment variable, list of hosts can be directly added to a customized version of plugin-config.json
+
 
 ### Visualize App events diagram using url:
 
 ```
-http://host:port/ops/apps-visualizer
+http://host:8098/ops/apps-visualizer
 ```
 
 ### To enable Live! events activity visualization, configure and start an instance of `log-streamer`:
@@ -29,9 +44,17 @@ http://host:port/ops/apps-visualizer
 #### Copy `config/plugin-config.json` and customize parameters to match your runtime environment. 
 
 
-#### Run a `hopeit_server` instance with log_streamer, in each node where you run your appplications:
+#### Run a `hopeit_server` instance with log_streamer, in each node where you run your applications:
 ```
 hopeit_server --port=8099 --start-streams --config-files=server-config.json,customized-plugin-config.json
 ```
 
 > Now when you can switch from `Static` to `Live` view clicking on the label at the top right of the Apps Visualizer page
+
+If you want also to monitor log-streamer app, you can set:
+
+```
+export HOPEIT_APPS_VISUALIZER_HOSTS=$HOPEIT_APPS_VISUALIZER_HOSTS,http://host:8099
+```
+
+and re-run apps-visualizer using `hopeit_server` command above.

--- a/plugins/ops/apps-visualizer/api/create_openapi_file.sh
+++ b/plugins/ops/apps-visualizer/api/create_openapi_file.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export PYTHONPATH=./plugins/ops/apps-visualizer/src/ && \
+export HOPEIT_APPS_VISUALIZER_HOSTS="in-process" && \
+hopeit_openapi create \
+--title="Simple Example" \
+--description="Simple Example" \
+--api-version="$(python -m hopeit.server.version APPS_API_VERSION)" \
+--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json \
+--output-file=plugins/ops/apps-visualizer/api/openapi.json

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -1,0 +1,1021 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "0.8",
+    "title": "Simple Example",
+    "description": "Simple Example"
+  },
+  "paths": {
+    "/api/config-manager/0x8/runtime-apps-config": {
+      "get": {
+        "summary": "Config Manager: Runtime Apps Config",
+        "description": "Returns the runtime config for the Apps running on this server",
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": false,
+            "description": "URL used to reach this server, informative",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Config info about running apps in current process",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeApps"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "config_manager.0x8"
+        ]
+      }
+    },
+    "/api/config-manager/0x8/cluster-apps-config": {
+      "get": {
+        "summary": "Config Manager: Cluster Apps Config",
+        "description": "Handle remote access to runtime configuration for a group of hosts",
+        "parameters": [
+          {
+            "name": "hosts",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of http://host:port strings",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Combined config info about running apps in provided list of hosts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeApps"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "config_manager.0x8"
+        ]
+      }
+    },
+    "/ops/apps-visualizer": {
+      "get": {
+        "summary": "App Visualizer: Site",
+        "description": "[Click here to open Events Graph](/ops/apps-visualizer)",
+        "parameters": [
+          {
+            "name": "app_prefix",
+            "in": "query",
+            "required": false,
+            "description": "app name prefix to filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "host_filter",
+            "in": "query",
+            "required": false,
+            "description": "host name filter substring",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand_queues",
+            "in": "query",
+            "required": false,
+            "description": "if `true` shows each stream queue as a separated stream",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "live",
+            "in": "query",
+            "required": false,
+            "description": "if `true` enable live stats refreshing",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML page with Events Graph",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "site.main"
+                  ],
+                  "properties": {
+                    "site.main": {
+                      "type": "string"
+                    }
+                  },
+                  "description": "site.main string payload"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "apps_visualizer.0x8"
+        ]
+      }
+    },
+    "/api/apps-visualizer/0x8/apps/events-graph": {
+      "get": {
+        "summary": "App Visualizer: Events Graph Data",
+        "description": "App Visualizer: Events Graph Data",
+        "parameters": [
+          {
+            "name": "app_prefix",
+            "in": "query",
+            "required": false,
+            "description": "app name prefix to filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "host_filter",
+            "in": "query",
+            "required": false,
+            "description": "host name filter substring",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand_queues",
+            "in": "query",
+            "required": false,
+            "description": "if `true` shows each stream queue as a separated stream",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "live",
+            "in": "query",
+            "required": false,
+            "description": "if `true` enable live stats refreshing",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Graph Data with applied Live Stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventsGraphResult"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "apps_visualizer.0x8"
+        ]
+      }
+    },
+    "/api/apps-visualizer/0x8/event-stats/live": {
+      "get": {
+        "summary": "App Visualizer: Live Stats",
+        "description": "App Visualizer: Live Stats",
+        "parameters": [
+          {
+            "name": "app_prefix",
+            "in": "query",
+            "required": false,
+            "description": "app name prefix to filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "host_filter",
+            "in": "query",
+            "required": false,
+            "description": "host name filter substring",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand_queues",
+            "in": "query",
+            "required": false,
+            "description": "if `true` shows each stream queue as a separated stream",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "live",
+            "in": "query",
+            "required": false,
+            "description": "if `true` enable live stats refreshing",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Graph Data with applied Live Stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventsGraphResult"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "apps_visualizer.0x8"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuntimeAppInfo": {
+        "type": "object",
+        "required": [
+          "servers",
+          "app_config"
+        ],
+        "properties": {
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerInfo"
+            }
+          },
+          "app_config": {
+            "$ref": "#/components/schemas/AppConfig"
+          }
+        },
+        "x-module-name": "hopeit.config_manager",
+        "description": "\n    Application config information associated to servers at runtime\n    "
+      },
+      "ServerInfo": {
+        "type": "object",
+        "required": [
+          "host_name",
+          "pid"
+        ],
+        "properties": {
+          "host_name": {
+            "type": "string"
+          },
+          "pid": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "default": "in-process"
+          }
+        },
+        "x-module-name": "hopeit.config_manager",
+        "description": "\n    Server info associated with runtime apps\n    "
+      },
+      "AppConfig": {
+        "type": "object",
+        "required": [
+          "app"
+        ],
+        "properties": {
+          "app": {
+            "$ref": "#/components/schemas/AppDescriptor"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/AppEngineConfig",
+            "default": {
+              "import_modules": null,
+              "read_stream_timeout": 1000,
+              "read_stream_interval": 1000,
+              "default_stream_compression": "lz4",
+              "default_stream_serialization": "json+base64",
+              "track_headers": [
+                "track.request_id",
+                "track.request_ts"
+              ],
+              "cors_origin": null
+            }
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              }
+            },
+            "default": {}
+          },
+          "events": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EventDescriptor"
+            },
+            "default": {}
+          },
+          "server": {
+            "$ref": "#/components/schemas/ServerConfig"
+          },
+          "plugins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppDescriptor"
+            },
+            "default": []
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    App Configuration container\n    "
+      },
+      "AppDescriptor": {
+        "type": "object",
+        "required": [
+          "name",
+          "version"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    App descriptor\n    "
+      },
+      "AppEngineConfig": {
+        "type": "object",
+        "properties": {
+          "import_modules": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "read_stream_timeout": {
+            "type": "integer",
+            "default": 1000
+          },
+          "read_stream_interval": {
+            "type": "integer",
+            "default": 1000
+          },
+          "default_stream_compression": {
+            "type": "string",
+            "enum": [
+              "none",
+              "lz4",
+              "lz4:0",
+              "lz4:16",
+              "zip",
+              "zip:1",
+              "zip:9",
+              "gzip",
+              "gzip:1",
+              "gzip:9",
+              "bz2",
+              "bz2:1",
+              "bz2:9",
+              "lzma"
+            ],
+            "x-enum-name": "Compression",
+            "x-module-name": "hopeit.app.config",
+            "default": "lz4"
+          },
+          "default_stream_serialization": {
+            "type": "string",
+            "enum": [
+              "json",
+              "json+base64",
+              "pickle:3",
+              "pickle:4",
+              "pickle:5"
+            ],
+            "x-enum-name": "Serialization",
+            "x-module-name": "hopeit.app.config",
+            "default": "json+base64"
+          },
+          "track_headers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "cors_origin": {
+            "type": "string"
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Engine specific parameters shared among events\n\n    :field import_modules: list of string with the python module names to import to find\n        events and datatype implementations\n    :field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n    :field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n        connection pool to be blocked constantly.\n    :track_headers: list of required X-Track-* headers\n    :cors_origin: allowed CORS origin for web server\n    "
+      },
+      "EventDescriptor": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "STREAM",
+              "SERVICE",
+              "MULTIPART"
+            ],
+            "x-enum-name": "EventType",
+            "x-module-name": "hopeit.app.config"
+          },
+          "plug_mode": {
+            "type": "string",
+            "enum": [
+              "Standalone",
+              "OnApp"
+            ],
+            "x-enum-name": "EventPlugMode",
+            "x-module-name": "hopeit.app.config",
+            "default": "Standalone"
+          },
+          "route": {
+            "type": "string"
+          },
+          "read_stream": {
+            "$ref": "#/components/schemas/ReadStreamDescriptor"
+          },
+          "write_stream": {
+            "$ref": "#/components/schemas/WriteStreamDescriptor"
+          },
+          "config": {
+            "$ref": "#/components/schemas/EventConfig",
+            "default": {
+              "response_timeout": 60.0,
+              "logging": {
+                "extra_fields": [],
+                "stream_fields": [
+                  "stream.name",
+                  "stream.msg_id",
+                  "stream.consumer_group"
+                ]
+              },
+              "stream": {
+                "timeout": 60.0,
+                "target_max_len": 0,
+                "throttle_ms": 0,
+                "step_delay": 0,
+                "batch_size": 100,
+                "compression": null,
+                "serialization": null
+              }
+            }
+          },
+          "auth": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Unsecured",
+                "Basic",
+                "Bearer",
+                "Refresh"
+              ],
+              "x-enum-name": "AuthType",
+              "x-module-name": "hopeit.server.config"
+            },
+            "default": []
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Event descriptor\n    "
+      },
+      "ReadStreamDescriptor": {
+        "type": "object",
+        "required": [
+          "name",
+          "consumer_group"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "queues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "AUTO"
+            ]
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Configuration to read streams\n\n    :field stream_name: str, base stream name to read\n    :consumer_group: str, consumer group to send to stream processing engine to keep track of\n        next messag to consume\n    :queues: List[str], list of queue names to poll from. Each queue act as separate stream\n        with queue name used as stream name suffix, where `AUTO` queue name means to consume\n        events when no queue where specified at publish time, allowing to consume message with different\n        priorities without waiting for all events in the stream to be consumed.\n        Queues specified in this entry will be consumed by this event\n        on each poll cycle, on the order specified. If not present\n        only AUTO queue will be consumed. Take into account that in applications using multiple\n        queue names, in order to ensure all messages are consumed, all queue names should be listed\n        here including AUTO, except that the app is intentionally designed for certain events to\n        consume only from specific queues. This configuration is manual to allow consuming messages\n        produced by external apps.\n    "
+      },
+      "WriteStreamDescriptor": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "queues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "AUTO"
+            ]
+          },
+          "queue_strategy": {
+            "type": "string",
+            "enum": [
+              "PROPAGATE",
+              "DROP"
+            ],
+            "x-enum-name": "StreamQueueStrategy",
+            "x-module-name": "hopeit.app.config",
+            "default": "DROP"
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Configuration to publish messages to a stream\n\n    :field: name, str: stream name\n    :field: queue, List[str], queue names to be used to publish to stream.\n        Each queue act as separate stream with queue name used as stream name suffix,\n        allowing to publish messages to i.e. a queue that will be consumed with priority,\n        or to multiple queues that will be consumed by different readers.\n        Queue suffix will be propagated through events, allowing an event in a defined queue\n        and successive events in following steps to be consumed using same queue name.\n        Notice that queue will be applied only to messages coming from default queue\n        (where queue is not specified at intial message creation). Messages consumed\n        from other queues will be published using same queue name as they have when consumed.\n    :field queue_stategory: strategy to be used when consuming messages from a stream\n        with a queue name and publishing to another stream. Default is `StreamQueueStrategy.DROP`,\n        so in case of complex stream propagating queue names are configured,\n        `StreamQueueStrategy.PROPAGATE` must be explicitly specified.\n    "
+      },
+      "EventConfig": {
+        "type": "object",
+        "properties": {
+          "response_timeout": {
+            "type": "number",
+            "default": 60.0
+          },
+          "logging": {
+            "$ref": "#/components/schemas/EventLoggingConfig",
+            "default": {
+              "extra_fields": [],
+              "stream_fields": [
+                "stream.name",
+                "stream.msg_id",
+                "stream.consumer_group"
+              ]
+            }
+          },
+          "stream": {
+            "$ref": "#/components/schemas/EventStreamConfig",
+            "default": {
+              "timeout": 60.0,
+              "target_max_len": 0,
+              "throttle_ms": 0,
+              "step_delay": 0,
+              "batch_size": 100,
+              "compression": null,
+              "serialization": null
+            }
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Event execution configuration\n    :field response_timeout: float, default 60.0: seconds to timeout waiting for event execution\n        when invoked externally .i.e. GET or POST events. If exceeded, Timed Out response will be returned.\n        Notice that this timeout does not apply for stream processing events. Use EventStreamsConfig.timeout\n        to set up timeout on stream processing.\n    :field logging: EventLoggingConfig, configuration for logging for this particular event\n    :field stream: EventStreamConfig, configuration for stream processing for this particular event\n    "
+      },
+      "EventLoggingConfig": {
+        "type": "object",
+        "properties": {
+          "extra_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "stream_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Logging configuration specific for the event\n\n    :field extra_fields: list of str, extra fields required to apps when logging\n        as part of extra(...) call\n    :field stream_fields: list of str, field names to extra when reading streams,\n        valid options are\n            'name': stream name,\n            'msg_id', internal message id\n            'consumer_group', conaumer group name\n            'submit_ts', utc time message was submited to stream\n            'event_ts', event timestamp from @data_event\n            'event_id', event id from @data_event\n            'read_ts': uct time when message was consumed from stream\n    "
+      },
+      "EventStreamConfig": {
+        "type": "object",
+        "properties": {
+          "timeout": {
+            "type": "number",
+            "default": 60.0
+          },
+          "target_max_len": {
+            "type": "integer",
+            "default": 0
+          },
+          "throttle_ms": {
+            "type": "integer",
+            "default": 0
+          },
+          "step_delay": {
+            "type": "integer",
+            "default": 0
+          },
+          "batch_size": {
+            "type": "integer",
+            "default": 100
+          },
+          "compression": {
+            "type": "string",
+            "enum": [
+              "none",
+              "lz4",
+              "lz4:0",
+              "lz4:16",
+              "zip",
+              "zip:1",
+              "zip:9",
+              "gzip",
+              "gzip:1",
+              "gzip:9",
+              "bz2",
+              "bz2:1",
+              "bz2:9",
+              "lzma"
+            ],
+            "x-enum-name": "Compression",
+            "x-module-name": "hopeit.app.config"
+          },
+          "serialization": {
+            "type": "string",
+            "enum": [
+              "json",
+              "json+base64",
+              "pickle:3",
+              "pickle:4",
+              "pickle:5"
+            ],
+            "x-enum-name": "Serialization",
+            "x-module-name": "hopeit.app.config"
+          }
+        },
+        "x-module-name": "hopeit.app.config",
+        "description": "\n    Stream configuration for STREAM events\n    :field timeout: float, timeout for stream processing im seconds. If timeout is exceeded event\n        processing will be cancelled. Default 60 seconds\n    :field target_max_len: int, default 0, max number of elements to be used as a target\n        for the stream collection size. Messages above this value might be dropped\n        from the collection when new items are added. Notice that the number of the items\n        in the collection could exceed temporary this value to allow optimized behaviour,\n        but no items will be dropped until the collection exceeds target_max_len.\n        With default value of 0, collection size is unlimited and items should be removed by apps.\n    :field throttle_ms: int, milliseconds specifying minimum duration for each event\n    :filed step_delay: int, milliseconds to sleep between steps\n    :field batch_size: int, number of max messages to process each time when reading stream,\n        set to 1 to ensure min losses in case of process stop, set higher for performance\n    :field compression: Compression, compression algorithm used to send messages to stream, if not specified\n        default from Server config will be used.\n    :field serialization: Serialization, serialization method used to send messages to stream, if not specified\n        default from Server config will be used.\n    "
+      },
+      "ServerConfig": {
+        "type": "object",
+        "properties": {
+          "streams": {
+            "$ref": "#/components/schemas/StreamsConfig",
+            "default": {
+              "stream_manager": "hopeit.streams.NoStreamManager",
+              "connection_str": "<<NoStreamManager>>",
+              "delay_auto_start_seconds": 3
+            }
+          },
+          "logging": {
+            "$ref": "#/components/schemas/LoggingConfig",
+            "default": {
+              "log_level": "INFO",
+              "log_path": "logs/"
+            }
+          },
+          "auth": {
+            "$ref": "#/components/schemas/AuthConfig",
+            "default": {
+              "secrets_location": "",
+              "auth_passphrase": "",
+              "enabled": false,
+              "create_keys": false,
+              "domain": null,
+              "encryption_algorithm": "RS256",
+              "default_auth_methods": [
+                "Unsecured"
+              ]
+            }
+          },
+          "api": {
+            "$ref": "#/components/schemas/APIConfig",
+            "default": {
+              "docs_path": null
+            }
+          },
+          "engine_version": {
+            "type": "string",
+            "default": "0.8.0"
+          }
+        },
+        "x-module-name": "hopeit.server.config",
+        "description": "\n    Server configuration\n    "
+      },
+      "StreamsConfig": {
+        "type": "object",
+        "properties": {
+          "stream_manager": {
+            "type": "string",
+            "default": "hopeit.streams.NoStreamManager"
+          },
+          "connection_str": {
+            "type": "string",
+            "default": "<<NoStreamManager>>"
+          },
+          "delay_auto_start_seconds": {
+            "type": "integer",
+            "default": 3
+          }
+        },
+        "x-module-name": "hopeit.server.config",
+        "description": "\n    :field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    "
+      },
+      "LoggingConfig": {
+        "type": "object",
+        "properties": {
+          "log_level": {
+            "type": "string",
+            "default": "INFO"
+          },
+          "log_path": {
+            "type": "string",
+            "default": "logs/"
+          }
+        },
+        "x-module-name": "hopeit.server.config",
+        "description": "LoggingConfig(log_level: str = 'INFO', log_path: str = 'logs/')"
+      },
+      "AuthConfig": {
+        "type": "object",
+        "required": [
+          "secrets_location",
+          "auth_passphrase"
+        ],
+        "properties": {
+          "secrets_location": {
+            "type": "string"
+          },
+          "auth_passphrase": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "create_keys": {
+            "type": "boolean",
+            "default": false
+          },
+          "domain": {
+            "type": "string"
+          },
+          "encryption_algorithm": {
+            "type": "string",
+            "default": "RS256"
+          },
+          "default_auth_methods": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Unsecured",
+                "Basic",
+                "Bearer",
+                "Refresh"
+              ],
+              "x-enum-name": "AuthType",
+              "x-module-name": "hopeit.server.config"
+            },
+            "default": []
+          }
+        },
+        "x-module-name": "hopeit.server.config",
+        "description": "\n    Server configuration to handle authorization tokens\n    "
+      },
+      "APIConfig": {
+        "type": "object",
+        "properties": {
+          "docs_path": {
+            "type": "string"
+          }
+        },
+        "x-module-name": "hopeit.server.config",
+        "description": "\n    Config for Open API docs page\n    "
+      },
+      "RuntimeApps": {
+        "type": "object",
+        "required": [
+          "apps"
+        ],
+        "properties": {
+          "apps": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RuntimeAppInfo"
+            }
+          },
+          "server_status": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "ALIVE",
+                "ERROR"
+              ],
+              "x-enum-name": "ServerStatus",
+              "x-module-name": "hopeit.config_manager"
+            },
+            "default": {}
+          }
+        },
+        "x-module-name": "hopeit.config_manager",
+        "description": "\n    Combined App Config and Server Sttus information for running apps\n    "
+      },
+      "VisualizationOptions": {
+        "type": "object",
+        "properties": {
+          "app_prefix": {
+            "type": "string",
+            "default": ""
+          },
+          "host_filter": {
+            "type": "string",
+            "default": ""
+          },
+          "expand_queues": {
+            "type": "boolean",
+            "default": false
+          },
+          "live": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "x-module-name": "hopeit.apps_visualizer.site.visualization",
+        "description": "VisualizationOptions(app_prefix: str = '', host_filter: str = '', expand_queues: bool = False, live: bool = False)"
+      },
+      "EventsGraphResult": {
+        "type": "object",
+        "required": [
+          "runtime_apps",
+          "options"
+        ],
+        "properties": {
+          "runtime_apps": {
+            "$ref": "#/components/schemas/RuntimeApps"
+          },
+          "options": {
+            "$ref": "#/components/schemas/VisualizationOptions"
+          }
+        },
+        "x-module-name": "hopeit.apps_visualizer.site.main",
+        "description": "EventsGraphResult(runtime_apps: hopeit.config_manager.RuntimeApps, options: hopeit.apps_visualizer.site.visualization.VisualizationOptions)"
+      }
+    },
+    "securitySchemes": {
+      "auth.basic": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "auth.bearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "security": [
+    {
+      "auth.bearer": []
+    }
+  ]
+}

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -959,7 +959,7 @@
           }
         },
         "x-module-name": "hopeit.config_manager",
-        "description": "\n    Combined App Config and Server Sttus information for running apps\n    "
+        "description": "\n    Combined App Config and Server Status information for running apps\n    "
       },
       "VisualizationOptions": {
         "type": "object",

--- a/plugins/ops/apps-visualizer/config/plugin-config.json
+++ b/plugins/ops/apps-visualizer/config/plugin-config.json
@@ -1,7 +1,7 @@
 {
     "app": {
         "name": "apps-visualizer",
-        "version": "${HOPEIT_APPS_API_VERSION}"
+        "version": "${APPS_API_VERSION}"
     },
     "engine" : {
         "import_modules": ["hopeit.apps_visualizer"],

--- a/plugins/ops/apps-visualizer/config/plugin-config.json
+++ b/plugins/ops/apps-visualizer/config/plugin-config.json
@@ -1,7 +1,7 @@
 {
     "app": {
         "name": "apps-visualizer",
-        "version": "${APPS_API_VERSION}"
+        "version": "${HOPEIT_APPS_API_VERSION}"
     },
     "engine" : {
         "import_modules": ["hopeit.apps_visualizer"],

--- a/plugins/ops/apps-visualizer/config/plugin-config.json
+++ b/plugins/ops/apps-visualizer/config/plugin-config.json
@@ -6,7 +6,15 @@
     "engine" : {
         "import_modules": ["hopeit.apps_visualizer"],
         "cors_origin": "http://localhost:8020"
-    },    
+    },
+    "env": {
+        "apps-visualizer": {
+            "hosts": "${HOPEIT_APPS_VISUALIZER_HOSTS}",
+            "refresh_hosts_seconds": 60,
+            "live_recent_treshold_seconds": 10,
+            "live_active_treshold_seconds": 60
+        }
+    },
     "events": {
         "site.main": {
             "type": "GET",

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/__init__.py
@@ -1,3 +1,6 @@
+"""
+Apps Visualizer plugin module
+"""
 from hopeit.dataobjects import dataclass, dataobject
 from hopeit.app.context import EventContext
 
@@ -19,10 +22,10 @@ class AppsVisualizerEnv:
         has been activated (border will be highlighted)
     """
     hosts: str
-    refresh_hosts_seconds: int = 60,
-    live_recent_treshold_seconds: int = 10,
+    refresh_hosts_seconds: int = 60
+    live_recent_treshold_seconds: int = 10
     live_active_treshold_seconds: int = 60
 
     @classmethod
     def from_context(cls, context: EventContext) -> "AppsVisualizerEnv":
-        return cls.from_dict(context.env['apps-visualizer'])
+        return cls.from_dict(context.env['apps-visualizer'])  # type: ignore

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/__init__.py
@@ -1,0 +1,28 @@
+from hopeit.dataobjects import dataclass, dataobject
+from hopeit.app.context import EventContext
+
+
+@dataobject
+@dataclass
+class AppsVisualizerEnv:
+    """
+    Apps visualizer env options.
+
+    Helper dataclasses to load "apps-visualizer" env section from plugin config.
+
+    :field: hosts, str: comma-separated list of `http://host:port` entries to contact to query
+        config-manager plugin for running apps layout
+    :field: refresh_hosts_seconds: int, default 60: interval to contact nodes config-manager
+    :field: live_recent_treshold_seconds, int, default 10: number of seconds to consider a node
+        recently activated (the complete box will be highlighted)
+    :field: live_active_treshold_seconds, int, default: 60: number of seconds to consider a node
+        has been activated (border will be highlighted)
+    """
+    hosts: str
+    refresh_hosts_seconds: int = 60,
+    live_recent_treshold_seconds: int = 10,
+    live_active_treshold_seconds: int = 60
+
+    @classmethod
+    def from_context(cls, context: EventContext) -> "AppsVisualizerEnv":
+        return cls.from_dict(context.env['apps-visualizer'])

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/__init__.py
@@ -1,0 +1,35 @@
+from typing import Optional
+import asyncio
+from datetime import datetime, timezone
+
+from hopeit.app.context import EventContext
+from hopeit.server.logger import engine_extra_logger
+
+from hopeit.config_manager import RuntimeApps
+from hopeit.config_manager.client import get_apps_config
+
+from hopeit.apps_visualizer import AppsVisualizerEnv
+
+logger, extra = engine_extra_logger()
+
+_lock = asyncio.Lock()
+_apps: Optional[RuntimeApps] = None
+_expire: float = 0.0
+
+async def get_runtime_apps(context: EventContext, refresh: bool = False) -> RuntimeApps:
+    """
+    Extract current runtime app_config objects
+    """
+    global _apps, _expire
+    if not refresh and _lock.locked():
+        raise RuntimeError("Events graph request in process. Ignoring")
+    env = AppsVisualizerEnv.from_context(context)
+    now_ts = datetime.now(tz=timezone.utc).timestamp()
+    async with _lock:
+        if _apps is None or refresh or now_ts > _expire:
+            logger.info(context, "Contacting hosts config-manager...")
+            _apps = await get_apps_config(env.hosts, context)
+            _expire = now_ts + env.refresh_hosts_seconds
+        else:
+            logger.info(context, "Using cached runtime apps information.")
+        return _apps

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/__init__.py
@@ -1,3 +1,6 @@
+"""
+Apps Visualizer apps state
+"""
 from typing import Optional
 import asyncio
 from datetime import datetime, timezone
@@ -15,6 +18,7 @@ logger, extra = engine_extra_logger()
 _lock = asyncio.Lock()
 _apps: Optional[RuntimeApps] = None
 _expire: float = 0.0
+
 
 async def get_runtime_apps(context: EventContext, refresh: bool = False) -> RuntimeApps:
     """

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
@@ -1,7 +1,7 @@
 """
 Collect Event Stats from log stream
 """
-from typing import Deque, Dict
+from typing import Deque, Dict, Set, Tuple
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 
@@ -34,13 +34,21 @@ async def consume(batch: LogBatch, context: EventContext) -> None:
     recent_entries.extend(batch.entries)
 
 
-def get_stats(time_window_secs: int, recent_secs: int) -> Dict[str, EventStats]:
+def get_stats(host_pids: Set[Tuple[str, str]], time_window_secs: int, recent_secs: int) -> Dict[str, EventStats]:
+    """
+    Collect node event stats, counting for each node with recent entries
+    number of started, done, pending and failed events.
+
+    :param: host_pids, str tuple, set of host-pid pairs to filter log entries
+    :param: time_window_secs: int, consider events not older than this
+    :param: recent_secs: int, events on the last seconds will be counted as recent 
+    """
     stats: Dict[str, EventStats] = defaultdict(EventStats)
     now_ts = datetime.now(tz=timezone.utc)
     from_ts = (now_ts - timedelta(seconds=time_window_secs)).strftime("%Y-%m-%d %H:%M:%S")
     recent_ts = (now_ts - timedelta(seconds=recent_secs)).strftime("%Y-%m-%d %H:%M:%S")
     for entry in recent_entries:
-        if entry.ts >= from_ts:
+        if entry.ts >= from_ts and (entry.host, entry.pid) in host_pids:
             event_name = entry.extra.get("stream.event_name", entry.event_name)
             event_name = f"{auto_path(entry.app_name, entry.app_version)}.{event_name}"
             event_stats = stats[event_name]

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
@@ -41,7 +41,7 @@ def get_stats(host_pids: Set[Tuple[str, str]], time_window_secs: int, recent_sec
 
     :param: host_pids, str tuple, set of host-pid pairs to filter log entries
     :param: time_window_secs: int, consider events not older than this
-    :param: recent_secs: int, events on the last seconds will be counted as recent 
+    :param: recent_secs: int, events on the last seconds will be counted as recent
     """
     stats: Dict[str, EventStats] = defaultdict(EventStats)
     now_ts = datetime.now(tz=timezone.utc)

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/live.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/live.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List
 
 from hopeit.apps_visualizer.site.visualization import VisualizationOptions
 from hopeit.app.api import event_api
@@ -6,7 +6,8 @@ from hopeit.app.events import collector_step, Collector
 from hopeit.app.context import EventContext
 
 from hopeit.apps_visualizer.event_stats.collect import get_stats
-from hopeit.apps_visualizer.site.visualization import visualization_options, visualization_options_api_args  # noqa: F401
+from hopeit.apps_visualizer.site.visualization import \
+    visualization_options, visualization_options_api_args  # noqa: F401
 from hopeit.apps_visualizer.apps.events_graph import EventsGraphResult, \
     config_graph, cytoscape_data, runtime_apps  # noqa: F401
 from hopeit.apps_visualizer import AppsVisualizerEnv

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
@@ -35,13 +35,21 @@
     </nav>
     <div class="container-fluid">
         <div class="row my-2">
-          <div class="col-8 dropdown">
+          <div class="col-8">
+          <div class="btn-group">
             <a class="btn btn-sm btn-outline-dark dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-              App: {{ app_prefix }}
+              Apps: {{ app_prefix }}
             </a>
-            <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-              {{ app_items }}
+            <ul id="appitems" class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             </ul>
+          </div>
+          <div class="btn-group">
+            <a class="btn btn-sm btn-outline-dark dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+              Servers: {{ host_filter }}
+            </a>
+            <ul id="serveritems" class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+            </ul>
+          </div>
           </div>
           <div class="col-4 text-end">
             <small><a class="badge bg-secondary" href="{{ view_link }}">{{ view_type }}</a></small>
@@ -131,21 +139,85 @@
         elements: [],
       });
 
-      var need_layout = true;
+      var needLayout = true;
+
+      const refreshGraph = (data) => {
+        items = Object.values(data)
+        needLayout = needLayout || (items.length != cy.elements().length)
+        cy.json({elements: items})
+        if (needLayout) {
+          cy.layout(options).run();
+          needLayout = false;
+        }
+      }
+
+      const refreshServers = (serverStatus, options) => {
+
+        const newItem = (host, desc) => {
+          li = document.createElement("li");
+          a = document.createElement("a");
+          a.className = "dropdown-item";
+          a.appendChild(document.createTextNode(desc));
+          if (options.host_filter && host.includes(options.host_filter)) {
+            a.className += " active";
+          }
+          a.setAttribute("href", `apps-visualizer?app_prefix=${options.app_prefix}` +
+            `&host_filter=${host}` +
+            `&expand_queues=${options.expand_queues}` +
+            `&live=${options.live}`);
+          li.appendChild(a);
+          return li
+        }
+
+        keys = Object.keys(serverStatus).sort();
+        lis = keys.map( host => {
+          return newItem(host, `${host}: ${serverStatus[host]}`);
+        });
+        allHosts = newItem("", "All servers")
+        serverItems = document.getElementById("serveritems");
+        serverItems.replaceChildren(allHosts, ...lis)
+      }
+
+      const refreshApps = (apps, options) => {
+
+        const newItem = (appName, desc) => {
+          li = document.createElement("li");
+          a = document.createElement("a");
+          a.className = "dropdown-item";
+          a.appendChild(document.createTextNode(desc));
+          if (options.app_prefix && appName.startsWith(options.app_prefix)) {
+            a.className += " active";
+          }
+          a.setAttribute("href", `apps-visualizer?app_prefix=${appName}` +
+            `&host_filter=${options.host_filter}` +
+            `&expand_queues=${options.expand_queues}` +
+            `&live=${options.live}`);
+          li.appendChild(a);
+          return li
+        }
+
+        keys = Object.keys(apps).sort()
+        lis = keys.map( appKey => {
+          appName = apps[appKey].app_config.app.name
+          return newItem(appName, appName)
+        });
+        allApps = newItem("", "All running apps")
+        serverItems = document.getElementById("appitems");
+        serverItems.replaceChildren(allApps, ...lis)
+      }
 
       const refresh = () => {
         $.getJSON("{{ refresh_endpoint }}", 
           function(result) {
-            cy.json({elements: Object.values(result.graph.data)})
-            if (need_layout) {
-              cy.layout(options).run();
-              need_layout = false;
-            }
+            refreshGraph(result.graph.data);
+            refreshApps(result.runtime_apps.apps, result.options);
+            refreshServers(result.runtime_apps.server_status, result.options);
           }
         );
       }
 
-      window.setInterval(refresh, 1000)
+      window.setTimeout(refresh, 500)
+      window.setInterval(refresh, 5000)
 
       function hashCode(s) {
         var h = 0;

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
@@ -8,26 +8,25 @@ from pathlib import Path
 
 from hopeit.app.context import EventContext, PostprocessHook
 
-from hopeit.apps_visualizer.site.visualization import VisualizationOptions, \
-    visualization_options  # noqa: F401
+from hopeit.apps_visualizer.apps import get_runtime_apps
+from hopeit.apps_visualizer.site.visualization import VisualizationOptions, visualization_options, visualization_options_api_args  # noqa: F401
+from hopeit.apps_visualizer.apps.events_graph import runtime_apps
 from hopeit.server.names import route_name
 from hopeit.app.api import event_api
 from hopeit.dataobjects import dataclass, dataobject
 from hopeit.app.config import AppConfig
 
+from hopeit.config_manager import RuntimeApps
+
 __steps__ = [
     'visualization_options',
-    'runtime_apps'
+    'runtime_apps_config'
 ]
 
 __api__ = event_api(
     summary="App Visualizer: Site",
     description="[Click here to open Events Graph](/ops/apps-visualizer)",
-    query_args=[
-        ("app_prefix", Optional[str], "app_key prefix to filter"),
-        ("expand_queues", Optional[bool], "if `true` shows each stream queue as a separated stream"),
-        ("live", Optional[bool], "if `true` enable live stats refreshing")
-    ],
+    query_args=visualization_options_api_args(),
     responses={
         200: (str, "HTML page with Events Graph")
     }
@@ -36,10 +35,10 @@ __api__ = event_api(
 _dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
 
-@dataobject
-@dataclass
-class RuntimeApps:
-    apps: List[AppConfig]
+# @dataobject
+# @dataclass
+# class RuntimeApps:
+#     apps: List[AppConfig]
 
 
 @dataobject
@@ -49,19 +48,12 @@ class EventsGraphResult:
     options: VisualizationOptions
 
 
-async def runtime_apps(options: VisualizationOptions, context: EventContext) -> EventsGraphResult:
+async def runtime_apps_config(options: VisualizationOptions, context: EventContext) -> EventsGraphResult:
     """
     Extract current runtime app_config objects
     """
-    server = getattr(sys.modules.get("hopeit.server.runtime"), "server")
-    apps = RuntimeApps(
-        apps=sorted(
-            (app.app_config for app in server.app_engines.values()),
-            key=lambda x: x.app_key()
-        )
-    )
     return EventsGraphResult(
-        runtime_apps=apps,
+        runtime_apps=await get_runtime_apps(context, refresh=True),
         options=options
     )
 
@@ -73,31 +65,19 @@ async def __postprocess__(result: EventsGraphResult, context: EventContext, resp
     response.set_content_type("text/html")
 
     app_prefix = result.options.app_prefix
-    app_names = [
-        ("All runtime apps", ""),
-        *((app_config.app.name, app_config.app.name) for app_config in result.runtime_apps.apps)
-    ]
-    app_items = '\n'.join(
-        [
-            f'<li><a class="dropdown-item'
-            f'{" active" if app_prefix and name[0:len(app_prefix)] == app_prefix else ""}"'
-            f' href="apps-visualizer?app_prefix={prefix}'
-            f"&expand_queues={str(result.options.expand_queues).lower()}"
-            f"&live={str(result.options.live).lower()}"
-            f'">{name}</a></li>'
-            for name, prefix in app_names
-        ]
-    )
 
     view_link = f"apps-visualizer?app_prefix={result.options.app_prefix}"
+    view_link += f"&host_filter={result.options.host_filter}"
     view_link += f"&expand_queues={str(not result.options.expand_queues).lower()}"
     view_link += f"&live={str(result.options.live).lower()}"
 
     live_link = f"apps-visualizer?app_prefix={result.options.app_prefix}"
+    live_link += f"&host_filter={result.options.host_filter}"
     live_link += f"&expand_queues={str(result.options.expand_queues).lower()}"
     live_link += f"&live={str(not result.options.live).lower()}"
 
-    app_prefix = result.options.app_prefix or 'All running apps'
+    app_prefix = f"{result.options.app_prefix}*" if result.options.app_prefix else 'All running apps'
+    host_filter = f"*{result.options.host_filter}*" if result.options.host_filter else 'All servers'
     view_type = "Expanded queues view" if result.options.expand_queues else "Standard view"
     live_type = "Live!" if result.options.live else "Static"
 
@@ -106,12 +86,14 @@ async def __postprocess__(result: EventsGraphResult, context: EventContext, resp
     )
     refresh_endpoint = route_name("api", context.app.name, context.app.version, *refresh_endpoint_comps)
     refresh_endpoint += f"?app_prefix={result.options.app_prefix}"
+    refresh_endpoint += f"&host_filter={result.options.host_filter}"
     refresh_endpoint += f"&expand_queues={str(result.options.expand_queues).lower()}"
+    refresh_endpoint += f"&live={str(result.options.live).lower()}"
 
     with open(_dir_path / 'events_graph_template.html') as f:
         template = f.read()
-        template = template.replace("{{ app_items }}", app_items)
         template = template.replace("{{ app_prefix }}", app_prefix)
+        template = template.replace("{{ host_filter }}", host_filter)
         template = template.replace("{{ view_link }}", view_link)
         template = template.replace("{{ live_link }}", live_link)
         template = template.replace("{{ refresh_endpoint }}", refresh_endpoint)

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
@@ -2,21 +2,19 @@
 Events graph showing events, stream and dependecies for specified apps
 """
 import os
-import sys
-from typing import List, Optional
 from pathlib import Path
 
 from hopeit.app.context import EventContext, PostprocessHook
 
-from hopeit.apps_visualizer.apps import get_runtime_apps
-from hopeit.apps_visualizer.site.visualization import VisualizationOptions, visualization_options, visualization_options_api_args  # noqa: F401
-from hopeit.apps_visualizer.apps.events_graph import runtime_apps
 from hopeit.server.names import route_name
 from hopeit.app.api import event_api
 from hopeit.dataobjects import dataclass, dataobject
-from hopeit.app.config import AppConfig
 
 from hopeit.config_manager import RuntimeApps
+
+from hopeit.apps_visualizer.apps import get_runtime_apps
+from hopeit.apps_visualizer.site.visualization import VisualizationOptions, \
+    visualization_options, visualization_options_api_args  # noqa: F401
 
 __steps__ = [
     'visualization_options',

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/visualization.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/visualization.py
@@ -2,7 +2,7 @@
 Visualization metadata
 """
 from hopeit.app.context import EventContext
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from dataclasses import dataclass, field
 
 from hopeit.dataobjects import dataobject
@@ -18,16 +18,27 @@ class CytoscapeGraph:
 @dataclass
 class VisualizationOptions:
     app_prefix: str = ''
+    host_filter: str = ''
     expand_queues: bool = False
     live: bool = False
+
+def visualization_options_api_args():
+    return [
+        ("app_prefix", Optional[str], "app name prefix to filter"),
+        ("host_filter", Optional[str], "host name filter substring"),
+        ("expand_queues", Optional[bool], "if `true` shows each stream queue as a separated stream"),
+        ("live", Optional[bool], "if `true` enable live stats refreshing")
+    ]
 
 
 async def visualization_options(payload: None, context: EventContext,
                                 *, app_prefix: str = '',
+                                host_filter: str = '',
                                 expand_queues: bool = False,
                                 live: bool = False) -> VisualizationOptions:
     return VisualizationOptions(
         app_prefix=app_prefix,
+        host_filter=host_filter,
         expand_queues=expand_queues is True or expand_queues == 'true',
         live=live is True or live == 'true'
     )

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/visualization.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/visualization.py
@@ -22,6 +22,7 @@ class VisualizationOptions:
     expand_queues: bool = False
     live: bool = False
 
+
 def visualization_options_api_args():
     return [
         ("app_prefix", Optional[str], "app name prefix to filter"),

--- a/plugins/ops/apps-visualizer/test/integration/__init__.py
+++ b/plugins/ops/apps-visualizer/test/integration/__init__.py
@@ -1,7 +1,4 @@
 from hopeit.app.config import AppConfig
-from hopeit.server.version import APPS_API_VERSION
-
-APP_VERSION = APPS_API_VERSION.replace('.', 'x')
 
 
 class MockAppEngine:

--- a/plugins/ops/apps-visualizer/test/integration/conftest.py
+++ b/plugins/ops/apps-visualizer/test/integration/conftest.py
@@ -4,16 +4,66 @@ from pathlib import Path
 from datetime import datetime
 
 import pytest
-from hopeit.testing.apps import config, execute_event
-from hopeit.log_streamer import LogRawBatch, LogBatch
 
-from . import APP_VERSION, APPS_API_VERSION
+from hopeit.server.version import APPS_API_VERSION, APPS_ROUTE_VERSION
+from hopeit.server import config as server_config
+from hopeit.testing.apps import config, execute_event
+
+from hopeit.log_streamer import LogRawBatch, LogBatch
+from hopeit.config_manager.runtime import runtime
+
+from . import MockServer
+from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
+import socket
+
+
+@pytest.fixture
+def runtime_apps(monkeypatch):
+    app_config = config('apps/examples/simple-example/config/app-config.json')
+    monkeypatch.setattr(
+        runtime,
+        "server",
+        MockServer(app_config)
+    )
+    return RuntimeApps(
+        apps={
+            app_config.app_key(): RuntimeAppInfo(
+                servers=[
+                    ServerInfo(
+                        host_name=socket.gethostname(),
+                        pid=str(os.getpid()),
+                        url="in-process"
+                    )
+                ],
+                app_config=app_config
+            )
+        },
+        server_status={
+            "in-process": ServerStatus.ALIVE
+        }
+    )
+
+
+@pytest.fixture
+def plugin_config(monkeypatch):
+
+    def getenv(var_name):
+        if var_name == "HOPEIT_APPS_VISUALIZER_HOSTS":
+            return "in-process"
+        elif var_name == "APPS_API_VERSION":
+            return APPS_API_VERSION
+        elif var_name == "APPS_ROUTE_VERSION":
+            return APPS_ROUTE_VERSION
+        raise NotImplementedError(var_name)
+
+    monkeypatch.setattr(server_config.os, 'getenv', getenv)
+    return config('plugins/ops/apps-visualizer/config/plugin-config.json')
 
 
 @pytest.fixture
 def events_graph_data():
     with open(Path(os.path.dirname(os.path.realpath(__file__))) / 'events_graph_data.json') as f:
-        json_str = f.read().replace("${APP_VERSION}", APP_VERSION)
+        json_str = f.read().replace("${APPS_ROUTE_VERSION}", APPS_ROUTE_VERSION)
         return json.loads(json_str)
 
 
@@ -28,15 +78,17 @@ async def log_entries() -> LogBatch:
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} query_something host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
         f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} query_something host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} save_something host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
-        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APP_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
-        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APP_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
-        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APP_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
-        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APP_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
-        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APP_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
-        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | FAILED | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APP_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
+        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
+        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
+        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
+        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
+        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
+        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | FAILED | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
     ])
     batch = await _process_log_entries(raw)
     ts = datetime.now()
     for entry in batch.entries:
         entry.ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+        entry.host = socket.gethostname()
+        entry.pid = str(os.getpid())
     return batch

--- a/plugins/ops/apps-visualizer/test/integration/conftest.py
+++ b/plugins/ops/apps-visualizer/test/integration/conftest.py
@@ -50,9 +50,9 @@ def plugin_config(monkeypatch):
     def getenv(var_name):
         if var_name == "HOPEIT_APPS_VISUALIZER_HOSTS":
             return "in-process"
-        elif var_name == "APPS_API_VERSION":
+        elif var_name == "HOPEIT_APPS_API_VERSION":
             return APPS_API_VERSION
-        elif var_name == "APPS_ROUTE_VERSION":
+        elif var_name == "HOPEIT_APPS_ROUTE_VERSION":
             return APPS_ROUTE_VERSION
         raise NotImplementedError(var_name)
 

--- a/plugins/ops/apps-visualizer/test/integration/events_graph_data.json
+++ b/plugins/ops/apps-visualizer/test/integration/events_graph_data.json
@@ -1,440 +1,440 @@
 {
-  "simple_example.${APP_VERSION}.list_somethings.GET": {
+  "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.list_somethings.GET",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
       "content": "GET"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.list_somethings": {
+  "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.list_somethings",
-      "content": "simple_example.${APP_VERSION}\nlist_somethings"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nlist_somethings"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.query_something.GET": {
+  "simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.query_something.GET",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
       "content": "GET"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.query_something": {
+  "simple_example.${APPS_ROUTE_VERSION}.query_something": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.query_something",
-      "content": "simple_example.${APP_VERSION}\nquery_something"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.query_something_extended.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.query_something_extended.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.query_something_extended": {
+  "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.query_something_extended",
-      "content": "simple_example.${APP_VERSION}\nquery_something_extended"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something_extended"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.save_something.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.save_something.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.save_something": {
+  "simple_example.${APPS_ROUTE_VERSION}.save_something": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.save_something",
-      "content": "simple_example.${APP_VERSION}\nsave_something"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.save_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nsave_something"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.download_something.GET": {
+  "simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.download_something.GET",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
       "content": "GET"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.download_something": {
+  "simple_example.${APPS_ROUTE_VERSION}.download_something": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.download_something",
-      "content": "simple_example.${APP_VERSION}\ndownload_something"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.download_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ndownload_something"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.upload_something.MULTIPART": {
+  "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.upload_something.MULTIPART",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
       "content": "MULTIPART"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.upload_something": {
+  "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.upload_something",
-      "content": "simple_example.${APP_VERSION}\nupload_something"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nupload_something"
     },
     "classes": "EVENT"
   },
-  ">simple_example.${APP_VERSION}.streams.something_event": {
+  ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
     "data": {
-      "id": ">simple_example.${APP_VERSION}.streams.something_event",
-      "content": "simple_example.${APP_VERSION}\nstreams.something_event"
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
     },
     "classes": "STREAM"
   },
-  "simple_example.${APP_VERSION}.service.something_generator": {
+  "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.service.something_generator",
-      "content": "simple_example.${APP_VERSION}\nservice.something_generator"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nservice.something_generator"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.streams.something_event.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.streams.something_event.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.streams.something_event": {
+  "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.streams.something_event",
-      "content": "simple_example.${APP_VERSION}\nstreams.something_event"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.streams.process_events": {
+  "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.streams.process_events",
-      "content": "simple_example.${APP_VERSION}\nstreams.process_events"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.process_events"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.collector.query_concurrently.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.collector.query_concurrently.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  "simple_example.${APP_VERSION}.collector.query_concurrently": {
+  "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.collector.query_concurrently",
-      "content": "simple_example.${APP_VERSION}\ncollector.query_concurrently"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.query_concurrently"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.collector.collect_spawn.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.collector.collect_spawn.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  ">simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first": {
+  ">simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first": {
     "data": {
-      "id": ">simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first",
-      "content": "simple_example.${APP_VERSION}\ncollector.collect_spawn.collector@load_first"
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.collect_spawn.collector@load_first"
     },
     "classes": "STREAM"
   },
-  "simple_example.${APP_VERSION}.collector.collect_spawn": {
+  "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.collector.collect_spawn",
-      "content": "simple_example.${APP_VERSION}\ncollector.collect_spawn"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.collect_spawn"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.collector.collect_spawn$spawn": {
+  "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.collector.collect_spawn$spawn",
-      "content": "simple_example.${APP_VERSION}\ncollector.collect_spawn$spawn"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.collect_spawn$spawn"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.shuffle.spawn_event.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.spawn_event.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  ">simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events": {
+  ">simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events": {
     "data": {
-      "id": ">simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events",
-      "content": "simple_example.${APP_VERSION}\nshuffle.spawn_event.spawn_many_events"
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.spawn_event.spawn_many_events"
     },
     "classes": "STREAM"
   },
-  "simple_example.${APP_VERSION}.shuffle.spawn_event": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.spawn_event",
-      "content": "simple_example.${APP_VERSION}\nshuffle.spawn_event"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.spawn_event"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.shuffle.spawn_event$update_status": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.spawn_event$update_status",
-      "content": "simple_example.${APP_VERSION}\nshuffle.spawn_event$update_status"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.spawn_event$update_status"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.shuffle.parallelize_event.POST": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.parallelize_event.POST",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
       "content": "POST"
     },
     "classes": "REQUEST"
   },
-  ">simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something": {
+  ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something": {
     "data": {
-      "id": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something",
-      "content": "simple_example.${APP_VERSION}\nshuffle.parallelize_event.fork_something"
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event.fork_something"
     },
     "classes": "STREAM"
   },
-  "simple_example.${APP_VERSION}.shuffle.parallelize_event": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.parallelize_event",
-      "content": "simple_example.${APP_VERSION}\nshuffle.parallelize_event"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event"
     },
     "classes": "EVENT"
   },
-  ">simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part": {
+  ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part": {
     "data": {
-      "id": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part",
-      "content": "simple_example.${APP_VERSION}\nshuffle.parallelize_event.process_first_part"
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event.process_first_part"
     },
     "classes": "STREAM"
   },
-  "simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part",
-      "content": "simple_example.${APP_VERSION}\nshuffle.parallelize_event$process_first_part"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event$process_first_part"
     },
     "classes": "EVENT"
   },
-  "simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status": {
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status": {
     "data": {
-      "id": "simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status",
-      "content": "simple_example.${APP_VERSION}\nshuffle.parallelize_event$update_status"
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event$update_status"
     },
     "classes": "EVENT"
   },
-  "edge_simple_example.${APP_VERSION}.list_somethings.GET": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.list_somethings.GET",
-      "source": "simple_example.${APP_VERSION}.list_somethings.GET",
-      "target": "simple_example.${APP_VERSION}.list_somethings",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.query_something.GET": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.query_something.GET",
-      "source": "simple_example.${APP_VERSION}.query_something.GET",
-      "target": "simple_example.${APP_VERSION}.query_something",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.query_something",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.query_something_extended.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.query_something_extended.POST",
-      "source": "simple_example.${APP_VERSION}.query_something_extended.POST",
-      "target": "simple_example.${APP_VERSION}.query_something_extended",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.save_something.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.save_something.POST",
-      "source": "simple_example.${APP_VERSION}.save_something.POST",
-      "target": "simple_example.${APP_VERSION}.save_something",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.save_something",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.download_something.GET": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.download_something.GET",
-      "source": "simple_example.${APP_VERSION}.download_something.GET",
-      "target": "simple_example.${APP_VERSION}.download_something",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.download_something",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.upload_something.MULTIPART": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.upload_something.MULTIPART",
-      "source": "simple_example.${APP_VERSION}.upload_something.MULTIPART",
-      "target": "simple_example.${APP_VERSION}.upload_something",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.streams.process_events.simple_example.${APP_VERSION}.streams.something_event.high-prio": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.streams.process_events.simple_example.${APP_VERSION}.streams.something_event.high-prio",
-      "source": ">simple_example.${APP_VERSION}.streams.something_event",
-      "target": "simple_example.${APP_VERSION}.streams.process_events",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
       "label": "high-prio"
     }
   },
-  "edge_simple_example.${APP_VERSION}.streams.process_events.simple_example.${APP_VERSION}.streams.something_event.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.streams.process_events.simple_example.${APP_VERSION}.streams.something_event.AUTO",
-      "source": ">simple_example.${APP_VERSION}.streams.something_event",
-      "target": "simple_example.${APP_VERSION}.streams.process_events",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.service.something_generator.simple_example.${APP_VERSION}.streams.something_event.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.service.something_generator.simple_example.${APP_VERSION}.streams.something_event.AUTO",
-      "source": "simple_example.${APP_VERSION}.service.something_generator",
-      "target": ">simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.streams.something_event.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.streams.something_event.POST",
-      "source": "simple_example.${APP_VERSION}.streams.something_event.POST",
-      "target": "simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.streams.something_event.simple_example.${APP_VERSION}.streams.something_event.high-prio": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.streams.something_event.simple_example.${APP_VERSION}.streams.something_event.high-prio",
-      "source": "simple_example.${APP_VERSION}.streams.something_event",
-      "target": ">simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": "high-prio"
     }
   },
-  "edge_simple_example.${APP_VERSION}.collector.query_concurrently.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.collector.query_concurrently.POST",
-      "source": "simple_example.${APP_VERSION}.collector.query_concurrently.POST",
-      "target": "simple_example.${APP_VERSION}.collector.query_concurrently",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.collector.collect_spawn.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.collector.collect_spawn.POST",
-      "source": "simple_example.${APP_VERSION}.collector.collect_spawn.POST",
-      "target": "simple_example.${APP_VERSION}.collector.collect_spawn",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.collector.collect_spawn$spawn.simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn.simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.collector.collect_spawn$spawn.simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first.AUTO",
-      "source": ">simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first",
-      "target": "simple_example.${APP_VERSION}.collector.collect_spawn$spawn",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn.simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.collector.collect_spawn.simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.collector.collect_spawn.simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first.AUTO",
-      "source": "simple_example.${APP_VERSION}.collector.collect_spawn",
-      "target": ">simple_example.${APP_VERSION}.collector.collect_spawn.collector@load_first",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.collector.collect_spawn$spawn.simple_example.${APP_VERSION}.streams.something_event.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.collector.collect_spawn$spawn.simple_example.${APP_VERSION}.streams.something_event.AUTO",
-      "source": "simple_example.${APP_VERSION}.collector.collect_spawn$spawn",
-      "target": ">simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn$spawn",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.spawn_event.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.spawn_event.POST",
-      "source": "simple_example.${APP_VERSION}.shuffle.spawn_event.POST",
-      "target": "simple_example.${APP_VERSION}.shuffle.spawn_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.spawn_event$update_status.simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status.simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.spawn_event$update_status.simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO",
-      "source": ">simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events",
-      "target": "simple_example.${APP_VERSION}.shuffle.spawn_event$update_status",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status.simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.spawn_event.simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.spawn_event.simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO",
-      "source": "simple_example.${APP_VERSION}.shuffle.spawn_event",
-      "target": ">simple_example.${APP_VERSION}.shuffle.spawn_event.spawn_many_events",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.spawn_event$update_status.simple_example.${APP_VERSION}.streams.something_event.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.spawn_event$update_status.simple_example.${APP_VERSION}.streams.something_event.AUTO",
-      "source": "simple_example.${APP_VERSION}.shuffle.spawn_event$update_status",
-      "target": ">simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event$update_status",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event.POST": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event.POST",
-      "source": "simple_example.${APP_VERSION}.shuffle.parallelize_event.POST",
-      "target": "simple_example.${APP_VERSION}.shuffle.parallelize_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something.AUTO",
-      "source": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something",
-      "target": "simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event.simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event.simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something.AUTO",
-      "source": "simple_example.${APP_VERSION}.shuffle.parallelize_event",
-      "target": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.fork_something",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part.AUTO",
-      "source": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part",
-      "target": "simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part.AUTO",
-      "source": "simple_example.${APP_VERSION}.shuffle.parallelize_event$process_first_part",
-      "target": ">simple_example.${APP_VERSION}.shuffle.parallelize_event.process_first_part",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part.simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$process_first_part",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
       "label": ""
     }
   },
-  "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APP_VERSION}.streams.something_event.AUTO": {
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
     "data": {
-      "id": "edge_simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APP_VERSION}.streams.something_event.AUTO",
-      "source": "simple_example.${APP_VERSION}.shuffle.parallelize_event$update_status",
-      "target": ">simple_example.${APP_VERSION}.streams.something_event",
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event$update_status",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
       "label": ""
     }
   }

--- a/plugins/ops/apps-visualizer/test/integration/test_event_stats.py
+++ b/plugins/ops/apps-visualizer/test/integration/test_event_stats.py
@@ -3,14 +3,11 @@ from collections import deque
 
 import pytest
 
-from hopeit.testing.apps import config, execute_event
-import hopeit.server.runtime as runtime
+from hopeit.testing.apps import execute_event
+from hopeit.server.version import APPS_ROUTE_VERSION
 
 from hopeit.log_streamer import LogBatch, LogEntry
 from hopeit.apps_visualizer.apps.events_graph import EventsGraphResult
-
-from . import MockServer, APP_VERSION
-
 
 recent_entries: Deque[LogEntry] = deque()
 
@@ -20,14 +17,7 @@ def mock_recent_entries(module, context):
 
 
 @pytest.mark.asyncio
-async def test_live_stats(monkeypatch, log_entries: LogBatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
+async def test_live_stats(log_entries: LogBatch, events_graph_data, runtime_apps, plugin_config):
     await execute_event(
         app_config=plugin_config, event_name="event-stats.collect", payload=log_entries,
         mocks=[mock_recent_entries]
@@ -38,78 +28,72 @@ async def test_live_stats(monkeypatch, log_entries: LogBatch, events_graph_data)
     )
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.query_something.GET'
+        f'simple_example.{APPS_ROUTE_VERSION}.query_something.GET'
     ]['classes'] == 'RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.query_something'
+        f'simple_example.{APPS_ROUTE_VERSION}.query_something'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.save_something.POST'
+        f'simple_example.{APPS_ROUTE_VERSION}.save_something.POST'
     ]['classes'] == 'PENDING RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.save_something'
+        f'simple_example.{APPS_ROUTE_VERSION}.save_something'
     ]['classes'] == 'EVENT PENDING RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.service.something_generator'
+        f'simple_example.{APPS_ROUTE_VERSION}.service.something_generator'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'>simple_example.{APP_VERSION}.streams.something_event'
+        f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event'
     ]['classes'] == 'RECENT STARTED STREAM'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.something_event.POST'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.POST'
     ]['classes'] == 'RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.something_event'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.process_events'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.process_events'
     ]['classes'] == 'EVENT FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.query_something.GET'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.query_something.GET'
     ]['classes'] == 'RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.save_something.POST'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.save_something.POST'
     ]['classes'] == 'PENDING RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.process_events.'
-        f'simple_example.{APP_VERSION}.streams.something_event.high-prio'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.process_events.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio'
     ]['classes'] == 'FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.process_events.'
-        f'simple_example.{APP_VERSION}.streams.something_event.AUTO'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.process_events.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO'
     ]['classes'] == 'FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.something_event.POST'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.something_event.POST'
     ]['classes'] == 'RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.something_event.'
-        f'simple_example.{APP_VERSION}.streams.something_event.high-prio'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.something_event.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio'
     ]['classes'] == 'RECENT STARTED'
 
 
 @pytest.mark.asyncio
-async def test_live_stats_expanded_view(monkeypatch, log_entries: LogBatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
+async def test_live_stats_expanded_view(log_entries: LogBatch, events_graph_data,
+                                        runtime_apps, plugin_config):
     await execute_event(
         app_config=plugin_config, event_name="event-stats.collect", payload=log_entries,
         mocks=[mock_recent_entries]
@@ -121,73 +105,73 @@ async def test_live_stats_expanded_view(monkeypatch, log_entries: LogBatch, even
     )
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.query_something.GET'
+        f'simple_example.{APPS_ROUTE_VERSION}.query_something.GET'
     ]['classes'] == 'RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.query_something'
+        f'simple_example.{APPS_ROUTE_VERSION}.query_something'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.save_something.POST'
+        f'simple_example.{APPS_ROUTE_VERSION}.save_something.POST'
     ]['classes'] == 'PENDING RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.save_something'
+        f'simple_example.{APPS_ROUTE_VERSION}.save_something'
     ]['classes'] == 'EVENT PENDING RECENT STARTED'
 
     assert result.graph.data[
-        f'>simple_example.{APP_VERSION}.streams.something_event.AUTO'
+        f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO'
     ]['classes'] == 'RECENT STARTED STREAM'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.service.something_generator'
+        f'simple_example.{APPS_ROUTE_VERSION}.service.something_generator'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.something_event.POST'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.POST'
     ]['classes'] == 'RECENT REQUEST STARTED'
 
     assert result.graph.data[
-        f'>simple_example.{APP_VERSION}.streams.something_event.high-prio'
+        f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio'
     ]['classes'] == 'RECENT STARTED STREAM'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.something_event'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event'
     ]['classes'] == 'EVENT RECENT STARTED'
 
     assert result.graph.data[
-        f'simple_example.{APP_VERSION}.streams.process_events'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.process_events'
     ]['classes'] == 'EVENT FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.query_something.GET'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.query_something.GET'
     ]['classes'] == 'RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.save_something.POST'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.save_something.POST'
     ]['classes'] == 'PENDING RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.process_events.'
-        f'simple_example.{APP_VERSION}.streams.something_event.AUTO'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.process_events.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO'
     ]['classes'] == 'FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.service.something_generator.'
-        f'simple_example.{APP_VERSION}.streams.something_event.AUTO'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.service.something_generator.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO'
     ]['classes'] == 'RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.something_event.POST'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.something_event.POST'
     ]['classes'] == 'RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.process_events.'
-        f'simple_example.{APP_VERSION}.streams.something_event.high-prio.high-prio'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.process_events.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio.high-prio'
     ]['classes'] == 'FAILED RECENT STARTED'
 
     assert result.graph.data[
-        f'edge_simple_example.{APP_VERSION}.streams.something_event.'
-        f'simple_example.{APP_VERSION}.streams.something_event.high-prio.high-prio'
+        f'edge_simple_example.{APPS_ROUTE_VERSION}.streams.something_event.'
+        f'simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio.high-prio'
     ]['classes'] == 'RECENT STARTED'

--- a/plugins/ops/apps-visualizer/test/integration/test_events_graph.py
+++ b/plugins/ops/apps-visualizer/test/integration/test_events_graph.py
@@ -1,67 +1,42 @@
 import pytest
 
-from hopeit.testing.apps import config, execute_event
-import hopeit.server.runtime as runtime
-
-from . import MockServer, APP_VERSION
+from hopeit.server.version import APPS_ROUTE_VERSION
+from hopeit.testing.apps import execute_event
 
 
 @pytest.mark.asyncio
-async def test_simple_example_events_diagram(monkeypatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
-
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
+async def test_simple_example_events_diagram(events_graph_data, runtime_apps, plugin_config):
     result = await execute_event(app_config=plugin_config, event_name="apps.events-graph", payload=None)
     assert result.graph.data == events_graph_data
     assert result.options.expand_queues is False
 
 
 @pytest.mark.asyncio
-async def test_simple_example_events_diagram_expand_queues(monkeypatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
-
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
+async def test_simple_example_events_diagram_expand_queues(events_graph_data,
+                                                           runtime_apps, plugin_config):
     result = await execute_event(
         app_config=plugin_config, event_name="apps.events-graph", payload=None, expand_queues="true"
     )
     streams = {
         k: v['data']
-        # x['data']['id']: x['data']
         for k, v in result.graph.data.items()
         if "STREAM" in v.get('classes', '')
     }
 
-    s1 = streams[f'>simple_example.{APP_VERSION}.streams.something_event.AUTO']
-    assert s1['id'] == f'>simple_example.{APP_VERSION}.streams.something_event.AUTO'
-    assert s1['content'] == f'simple_example.{APP_VERSION}\nstreams.something_event'
+    s1 = streams[f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO']
+    assert s1['id'] == f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.AUTO'
+    assert s1['content'] == f'simple_example.{APPS_ROUTE_VERSION}\nstreams.something_event'
 
-    s2 = streams[f'>simple_example.{APP_VERSION}.streams.something_event.high-prio']
-    assert s2['id'] == f'>simple_example.{APP_VERSION}.streams.something_event.high-prio'
-    assert s2['content'] == f'simple_example.{APP_VERSION}\nstreams.something_event.high-prio'
+    s2 = streams[f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio']
+    assert s2['id'] == f'>simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio'
+    assert s2['content'] == f'simple_example.{APPS_ROUTE_VERSION}\nstreams.something_event.high-prio'
 
     assert result.options.expand_queues is True
 
 
 @pytest.mark.asyncio
-async def test_simple_example_events_diagram_filter_apps(monkeypatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
-
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config, plugin_config)
-    )
+async def test_simple_example_events_diagram_filter_apps(events_graph_data,
+                                                         runtime_apps, plugin_config):
     result = await execute_event(
         app_config=plugin_config, event_name="apps.events-graph", payload=None,
         app_prefix="simple-example"

--- a/plugins/ops/apps-visualizer/test/integration/test_site.py
+++ b/plugins/ops/apps-visualizer/test/integration/test_site.py
@@ -1,37 +1,24 @@
 import pytest
 
-from hopeit.testing.apps import config, execute_event
-import hopeit.server.runtime as runtime
-
-from . import MockServer
+from hopeit.testing.apps import execute_event
 
 
-def check_replacements(page: str):
-    assert '{{ app_items }}' not in page
+@pytest.mark.asyncio
+async def test_site_main(monkeypatch, events_graph_data, runtime_apps, plugin_config):
+    result, page, _ = await execute_event(
+        app_config=plugin_config, event_name="site.main", payload=None, postprocess=True
+    )
+
+    assert result.runtime_apps == runtime_apps
+    assert result.options.app_prefix == ''
+    assert result.options.host_filter == ''
+    assert result.options.expand_queues is False
+    assert result.options.live is False
+
     assert '{{ app_prefix }}' not in page
+    assert '{{ host_filter }}' not in page
     assert '{{ view_link }}' not in page
     assert '{{ live_link }}' not in page
     assert '{{ refresh_endpoint }}' not in page
     assert '{{ view_type }}' not in page
     assert '{{ live_type }}' not in page
-
-
-@pytest.mark.asyncio
-async def test_site_main(monkeypatch, events_graph_data):
-    app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
-    )
-
-    plugin_config = config('plugins/ops/apps-visualizer/config/plugin-config.json')
-    result, page, _ = await execute_event(
-        app_config=plugin_config, event_name="site.main", payload=None, postprocess=True
-    )
-    assert result.runtime_apps.apps == [app_config]
-    assert result.options.app_prefix == ''
-    assert result.options.expand_queues is False
-    assert result.options.live is False
-
-    check_replacements(page)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/__init__.py
@@ -39,7 +39,7 @@ class RuntimeAppInfo:
 @dataclass
 class RuntimeApps:
     """
-    Combined App Config and Server Sttus information for running apps
+    Combined App Config and Server Status information for running apps
     """
     apps: Dict[str, RuntimeAppInfo]
     server_status: Dict[str, ServerStatus] = field(default_factory=dict)

--- a/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
@@ -1,0 +1,28 @@
+"""
+Manage access to server runtime running applications
+"""
+import socket
+import os
+
+from hopeit.server import runtime
+
+from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
+
+
+def get_in_process_config(url: str):
+    return RuntimeApps(
+        apps={
+            app_key: RuntimeAppInfo(
+                servers=[ServerInfo(
+                    host_name=socket.gethostname(),
+                    pid=str(os.getpid()),
+                    url=url
+                )],
+                app_config=app_engine.app_config
+            )
+            for app_key, app_engine in runtime.server.app_engines.items()
+        },
+        server_status={
+            url: ServerStatus.ALIVE
+        }
+    )

--- a/plugins/ops/config-manager/src/hopeit/config_manager/runtime_apps_config.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/runtime_apps_config.py
@@ -4,16 +4,13 @@ Config Manager: Runtime Apps Config
 Returns runtime configuration of running server
 """
 from typing import Optional
-import socket
-import os
-
-from hopeit.server.runtime import server
 
 from hopeit.app.context import EventContext
 from hopeit.app.logger import app_extra_logger
 
-from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
+from hopeit.config_manager import RuntimeApps
 from hopeit.app.api import event_api
+from hopeit.config_manager.runtime import get_in_process_config
 
 logger, extra = app_extra_logger()
 
@@ -30,19 +27,4 @@ __api__ = event_api(
 
 
 async def get_apps_config(payload: None, context: EventContext, *, url: str = "in-process") -> RuntimeApps:
-    return RuntimeApps(
-        apps={
-            app_key: RuntimeAppInfo(
-                servers=[ServerInfo(
-                    host_name=socket.gethostname(),
-                    pid=str(os.getpid()),
-                    url=url
-                )],
-                app_config=app_engine.app_config
-            )
-            for app_key, app_engine in server.app_engines.items()
-        },
-        server_status={
-            url: ServerStatus.ALIVE
-        }
-    )
+    return get_in_process_config(url)

--- a/plugins/ops/log-streamer/config/plugin-config.json
+++ b/plugins/ops/log-streamer/config/plugin-config.json
@@ -9,7 +9,7 @@
   "env" : {
     "log_reader": {
         "logs_path": "work/logs/apps/",
-        "prefix": "simple_example",
+        "prefix": "",
         "checkpoint_path": "work/logs/checkpoint/",
         "file_open_timeout_secs": 600,
         "file_checkpoint_expire_secs": 86400,

--- a/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
+++ b/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
@@ -45,6 +45,8 @@ class LogEntry:
     event_name: str
     event: str
     extra: Dict[str, str]
+    host: str = ''
+    pid: str = ''
 
 
 @dataobject

--- a/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
+++ b/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
@@ -20,6 +20,9 @@ logger, extra = app_extra_logger()
 @dataobject
 @dataclass
 class LogReaderConfig:
+    """
+    Log reader config env section
+    """
     logs_path: str
     prefix: str = ''
     checkpoint_path: str = 'log_streamer/checkpoints/'
@@ -32,12 +35,18 @@ class LogReaderConfig:
 @dataobject
 @dataclass
 class LogRawBatch:
+    """
+    Batch of raw lines read from logs
+    """
     data: List[str]
 
 
 @dataobject
 @dataclass
 class LogEntry:
+    """
+    Parsed log line
+    """
     ts: str
     msg: str
     app_name: str
@@ -52,6 +61,9 @@ class LogEntry:
 @dataobject
 @dataclass
 class LogBatch:
+    """
+    Batch of parsed log entries
+    """
     entries: List[LogEntry]
 
 

--- a/plugins/ops/log-streamer/src/hopeit/log_streamer/log_reader.py
+++ b/plugins/ops/log-streamer/src/hopeit/log_streamer/log_reader.py
@@ -72,7 +72,7 @@ async def _process_log_entry(entry: str, context: EventContext) -> Optional[LogE
             ts, app_info, msg, extras = xs[0], xs[2], xs[3], xs[4:]
             app_info_components = app_info.split(' ')
             if msg in {'START', 'DONE', 'FAILED'} and (len(app_info_components) >= 3):
-                app_name, app_version, event_name = app_info_components[:3]
+                app_name, app_version, event_name, host, pid = app_info_components[:5]
                 event = f"{auto_path(app_name, app_version)}.{event_name}"
                 extra_items = _parse_extras(extras)
                 return LogEntry(
@@ -82,7 +82,9 @@ async def _process_log_entry(entry: str, context: EventContext) -> Optional[LogE
                     app_version=app_version,
                     event_name=event_name,
                     event=event,
-                    extra=extra_items
+                    extra=extra_items,
+                    host=host,
+                    pid=pid
                 )
         return None
     except Exception as e:  # pylint: disable=broad-except  # pragma: no cover

--- a/plugins/ops/log-streamer/test/integration/conftest.py
+++ b/plugins/ops/log-streamer/test/integration/conftest.py
@@ -49,7 +49,9 @@ def expected_log_entries() -> LogBatch:
         "track.request_ts": "2021-06-02T18:01:44.289394+00:00",
         "track.caller": "test",
         "track.session_id": "test"
-      }
+      },
+      "host": "host",
+      "pid": "17031"
     },
     {
       "ts": "2021-06-02 18:01:44,303",
@@ -66,7 +68,9 @@ def expected_log_entries() -> LogBatch:
         "track.request_ts": "2021-06-02T18:01:44.289394+00:00",
         "track.caller": "test",
         "track.session_id": "test"
-      }
+      },
+      "host": "host",
+      "pid": "17031"
     }
   ]
 }


### PR DESCRIPTION
### Apps Visualizer

This version of apps visualizer support remote monitoring to multiple hosts.

It adds:
- List of hosts to connect specified on startup (hosts need to run config-manager plugin)
- Returns a host status (ALIVE if OK, ERROR if hosts config-manager fails)
- Filter by host substring
- Dynamically build list of apps when querying config-manager from nodes
- Updates server status, apps list and graph layout when detected changes (i.e. a node goes down, or its configuration is changed). This refresh is configurable, by default every 60 secs.

### Try it out

```
nohup make PORT=8020 run-simple-example &
nohup make PORT=8021 run-simple-example &
nohup make PORT=8099 run-log-streamer &

make PORT=8098 HOSTS=in-process,http://localhost:8099,http://localhost:8020,http://localhost:8021,http://localhost:7777 run-apps-visualizer
```
