### PR TITLE
fix(engine): Fixed management route names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,7 @@
             "args": [
                 "--port=8099",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/ops/log-streamer/config/plugin-config.json"
+                "--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/log-streamer/config/plugin-config.json"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1970,7 +1970,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.8.0"
+            "default": "0.8.2"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,11 @@ Release Notes
 =============
 
 
+Version 0.8.2
+_____________
+- Fix: some management routes to start/stop streams were not working: normalized $ sign to / in route names.
+
+
 Version 0.8.1
 _____________
 - `hopeit.dataobjects.jsonify` module: added utility functions to convert dictionaries and list to dataobjects and back

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -103,7 +103,7 @@ def _method_summary(module: str, summary: Optional[str] = None) -> str:
         return summary
     doc_str = inspect.getdoc(module)
     if doc_str is not None:
-        return doc_str.split("\n")[0]
+        return doc_str.split("\n", maxsplit=1)[0]
     return ""
 
 

--- a/engine/src/hopeit/server/logger.py
+++ b/engine/src/hopeit/server/logger.py
@@ -11,7 +11,7 @@ from logging.handlers import WatchedFileHandler
 from typing import Dict, Iterable, Union, List, Tuple, Callable, Any
 from stringcase import snakecase  # type: ignore
 
-import hopeit.server.version as version
+from hopeit.server import version
 from hopeit.app.config import EventDescriptor, AppDescriptor, AppConfig
 from hopeit.app.context import EventContext
 from hopeit.server.errors import json_exc

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.8.1"
+ENGINE_VERSION = "0.8.2"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -41,7 +41,7 @@ from hopeit.server.errors import ErrorInfo
 from hopeit.server.names import route_name
 from hopeit.server.api import app_route_name
 from hopeit.app.config import AppConfig, EventType, EventDescriptor, parse_app_config_json, EventPlugMode
-import hopeit.server.runtime as runtime
+from hopeit.server import runtime
 
 __all__ = ['parse_args',
            'main',

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -304,8 +304,8 @@ def _create_event_management_routes(
     """
     Create routes to start and stop processing of STREAM events
     """
-    app = app_engine.app_config.app
-    base_route = app_route_name(app_engine.app_config.app, event_name=event_name,
+    evt = event_name.replace('.', '/').replace('$', '/')
+    base_route = app_route_name(app_engine.app_config.app, event_name=evt,
                                 prefix='mgmt', override_route_name=event_info.route)
     logger.info(__name__, f"{event_info.type.value.upper()} path={base_route}/[start|stop]")
 
@@ -316,9 +316,9 @@ def _create_event_management_routes(
         handler = partial(_handle_service_start_invocation, app_engine, event_name)
     assert handler is not None, f"No handler for event={event_name} type={event_info.type}"
     return [
-        web.get(route_name('mgmt', app.name, app.version, event_name.replace('.', '/'), 'start'), handler),
+        web.get(base_route + '/start', handler),
         web.get(
-            route_name('mgmt', app.name, app.version, event_name.replace('.', '/'), 'stop'),
+            base_route + '/stop',
             partial(_handle_event_stop_invocation, app_engine, event_name)
         )
     ]

--- a/engine/src/hopeit/toolkit/auth.py
+++ b/engine/src/hopeit/toolkit/auth.py
@@ -47,12 +47,14 @@ def init(auth_config: AuthConfig):
         public_key_path = pathlib.Path(auth_config.secrets_location) / 'key_pub.pem'
         passphrase = auth_config.auth_passphrase.encode()
         try:
-            private_key = load_pem_private_key(
-                open(private_key_path, 'rb').read(),
-                passphrase, default_backend())
-            public_key = load_pem_public_key(
-                open(public_key_path, 'rb').read(),
-                default_backend())
+            with open(private_key_path, 'rb') as f:
+                private_key = load_pem_private_key(
+                    f.read(), passphrase, default_backend()
+                )
+            with open(public_key_path, 'rb') as f:
+                public_key = load_pem_public_key(
+                    f.read(), default_backend()
+                )
             logger.info(__name__, f"Found keys in {auth_config.secrets_location}")
         except FileNotFoundError as e:
             if auth_config.create_keys:

--- a/plugins/auth/basic-auth/src/hopeit/basic_auth/__init__.py
+++ b/plugins/auth/basic-auth/src/hopeit/basic_auth/__init__.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta
 import random
 
-import hopeit.toolkit.auth as auth
 from hopeit.app.api import app_base_route_name
 from hopeit.app.config import AppDescriptor
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.dataobjects import dataobject
 from hopeit.server.config import AuthType
+from hopeit.toolkit import auth
 
 __all__ = [
     'ContextUserInfo',

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -835,7 +835,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.8.0"
+            "default": "0.8.2"
           }
         },
         "x-module-name": "hopeit.server.config",


### PR DESCRIPTION
Normalized $ signs in event names to / to prevent `404: Not found` when calling some management routes to start/stop stream events or services.

Fixes #97 