### PR TITLE
fix(ci) Run single make qa before publishing to PyPi

### DIFF
--- a/.github/workflows/hopeit-engine-pypi-publishing.yml
+++ b/.github/workflows/hopeit-engine-pypi-publishing.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Install dependencies
       run: |
         make locked-deps
+    - name: QA
+      run: |
+        make qa
 
     - name: make hopeit.engine package
       run: |

--- a/Makefile
+++ b/Makefile
@@ -61,19 +61,14 @@ install-plugin:
 qa: test check
 	echo "DONE."
 
-dist: clean check test
+dist: clean
 	pip install wheel && \
 	cd engine && \
 	python setup.py sdist bdist_wheel
 
-dist-plugin: clean-plugins check-plugins test-plugins
+dist-plugin: clean-plugins
 	pip install wheel && \
 	cd $(PLUGINFOLDER) && \
-	python setup.py sdist bdist_wheel
-
-dist-only: clean
-	pip install wheel && \
-	cd engine && \
 	python setup.py sdist bdist_wheel
 
 clean:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Version 0.9.1
+_____________
+- Run single QA pipeline before publishing to PyPi
+
 
 Version 0.9.0
 _____________

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.9.0"
+ENGINE_VERSION = "0.9.1"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])


### PR DESCRIPTION
- Removed check-plugin test-plugin calls when making dist plugins
- Make a single QA call before releasing to PyPi
