### PR TITLE
plugin(apps-client) Support for OnApp plugin endpoints call

### DIFF
--- a/apps/benchmark/simple-benchmark/api/openapi.json
+++ b/apps/benchmark/simple-benchmark/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.9",
+    "version": "0.10",
     "title": "Simple Benchmark",
     "description": "Simple Benchmark App"
   },
   "paths": {
-    "/api/simple-benchmark/0x9/give-me-something": {
+    "/api/simple-benchmark/0x10/give-me-something": {
       "get": {
         "summary": "Simple Benchamrck: Give me Something",
         "description": "Loads Something from disk",
@@ -53,11 +53,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x9"
+          "simple_benchmark.0x10"
         ]
       }
     },
-    "/api/simple-benchmark/0x9/query-something-fs": {
+    "/api/simple-benchmark/0x10/query-something-fs": {
       "get": {
         "summary": "Simple Benchamrck: Query Something",
         "description": "Loads Something from disk",
@@ -114,11 +114,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x9"
+          "simple_benchmark.0x10"
         ]
       }
     },
-    "/api/simple-benchmark/0x9/save-something-fs": {
+    "/api/simple-benchmark/0x10/save-something-fs": {
       "post": {
         "summary": "Simple Benchmark: Save Something",
         "description": "Creates and saves Something",
@@ -176,11 +176,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x9"
+          "simple_benchmark.0x10"
         ]
       }
     },
-    "/api/simple-benchmark/0x9/query-something-redis": {
+    "/api/simple-benchmark/0x10/query-something-redis": {
       "get": {
         "summary": "Simple Benchamrck: Query Something",
         "description": "Loads Something from disk",
@@ -237,11 +237,11 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x9"
+          "simple_benchmark.0x10"
         ]
       }
     },
-    "/api/simple-benchmark/0x9/save-something-redis": {
+    "/api/simple-benchmark/0x10/save-something-redis": {
       "post": {
         "summary": "Simple Benchmark: Save Something",
         "description": "Creates and saves Something",
@@ -299,7 +299,7 @@
           }
         },
         "tags": [
-          "simple_benchmark.0x9"
+          "simple_benchmark.0x10"
         ]
       }
     }

--- a/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
+++ b/apps/benchmark/simple-benchmark/test/benchmark-docker.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-fs?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/give-me-something?item_id=string"
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/give-me-something?item_id=string"
+echo ./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/give-me-something?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-redis?item_id=string"
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-redis?item_id=string"
+echo ./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-redis?item_id=string"
 sleep 5
-echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-fs?item_id=string"
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-fs?item_id=string"
+echo ./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-fs?item_id=string"

--- a/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
+++ b/apps/benchmark/simple-benchmark/test/warm-up-fs.sh
@@ -7,6 +7,6 @@ else
   host=localhost
 fi
 for i in {1..2000}; do
-  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/0x9/save-something-fs"
+  curl --silent --output /dev/null -d '{"id": "string", "user": "string"}' -H 'Content-Type: application/json' "http://$host:8021/api/simple-benchmark/0x10/save-something-fs"
 done
 echo Done.

--- a/apps/build/ci-static-apps.sh
+++ b/apps/build/ci-static-apps.sh
@@ -16,11 +16,11 @@ python3 -m pylint apps/examples/simple-example/src/
 code+=$?
 
 echo "apps/client-example"
-export MYPYPATH=engine/src/:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages -p client_example
+export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages -p client_example
 code+=$?
-export MYPYPATH=engine/src/:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages apps/examples/client-example/test/unit/
+export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages apps/examples/client-example/test/unit/
 code+=$?
-export MYPYPATH=engine/src/:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages apps/examples/client-example/test/integration/
+export MYPYPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m mypy --namespace-packages apps/examples/client-example/test/integration/
 code+=$?
 python3 -m flake8 --max-line-length=120 apps/examples/client-example/src/ apps/examples/client-example/test/unit/ apps/examples/client-example/test/integration/
 code+=$?

--- a/apps/build/ci-test-apps.sh
+++ b/apps/build/ci-test-apps.sh
@@ -8,7 +8,7 @@ export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:plugins/storage/fs/src
 code+=$?
 
 echo "apps/client-example"
-export PYTHONPATH=engine/src/:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=apps/examples/client-example/src/ apps/examples/client-example/test/unit/ apps/examples/client-example/test/integration/
+export PYTHONPATH=engine/src/:plugins/auth/basic-auth/src:apps/examples/simple-example/src/:apps/examples/client-example/src/ && python3 -m pytest -v --cov-fail-under=90 --cov-report=term --cov=apps/examples/client-example/src/ apps/examples/client-example/test/unit/ apps/examples/client-example/test/integration/
 code+=$?
 
 if [ $code -gt 0 ]

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.9",
+    "version": "0.10",
     "title": "Client Example",
     "description": "Client Example"
   },
   "paths": {
-    "/api/config-manager/0x9/runtime-apps-config": {
+    "/api/config-manager/0x10/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
-    "/api/config-manager/0x9/cluster-apps-config": {
+    "/api/config-manager/0x10/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,11 +122,11 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
-    "/api/client-example/0x9/count-and-save": {
+    "/api/client-example/0x10/count-and-save": {
       "get": {
         "summary": "Client Example: Count Objects and Save new one",
         "description": "Count all available Something objects connecting to simple-example app",
@@ -193,7 +193,7 @@
           }
         },
         "tags": [
-          "client_example.0x9"
+          "client_example.0x10"
         ],
         "security": [
           {
@@ -771,7 +771,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.9.4"
+            "default": "0.10.0"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -434,6 +434,12 @@
           },
           "settings": {
             "type": "string"
+          },
+          "plugin_name": {
+            "type": "string"
+          },
+          "plugin_version": {
+            "type": "string"
           }
         },
         "x-module-name": "hopeit.app.config",

--- a/apps/examples/client-example/config/app-config.json
+++ b/apps/examples/client-example/config/app-config.json
@@ -8,13 +8,27 @@
         "cors_origin": "*"
     }, 
     "app_connections": {
+        "simple_example_auth_conn": {
+            "name": "simple-example",
+            "version": "${HOPEIT_APPS_API_VERSION}",
+            "plugin_name": "basic-auth",
+            "plugin_version": "${HOPEIT_APPS_API_VERSION}",
+            "client": "hopeit.apps_client.AppsClient"
+        },
         "simple_example_conn": {
             "name": "simple-example",
             "version": "${HOPEIT_APPS_API_VERSION}",
             "client": "hopeit.apps_client.AppsClient"
         }
+
     },
     "settings": {
+        "simple_example_auth_conn": {
+            "connection_str": "${HOPEIT_SIMPLE_EXAMPLE_HOSTS}",
+            "auth_strategy": "FORWARD_CONTEXT",
+            "retries": 2,
+            "retry_backoff_ms": 10
+        },
         "simple_example_conn": {
             "connection_str": "${HOPEIT_SIMPLE_EXAMPLE_HOSTS}",
             "circuit_breaker_open_failures": 10,
@@ -26,6 +40,7 @@
             "max_connections": 100,
             "max_connections_per_host": 0,
             "dns_cache_ttl": 10,
+            "auth_strategy": "CLIENT_APP_PUBLIC_KEY",
             "routes_override": {
                 "__list-somethings": "simple-example/${HOPEIT_APPS_ROUTE_VERSION}/list-somethings"
             }
@@ -35,6 +50,11 @@
         "count_and_save": {
             "type": "GET",
             "connections": [
+                {
+                    "app_connection": "simple_example_auth_conn",
+                    "event": "login",
+                    "type": "GET"
+                },
                 {
                     "app_connection": "simple_example_conn",
                     "event": "list_somethings",

--- a/apps/examples/client-example/setup.py
+++ b/apps/examples/client-example/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
     python_requires=">=3.7",
     install_requires=[
         f"hopeit.engine[web,cli,apps-client]=={version['ENGINE_VERSION']}",
+        f"hopeit.basic-auth=={version['ENGINE_VERSION']}",
         f"simple-example=={version['ENGINE_VERSION']}"
     ],
     extras_require={

--- a/apps/examples/client-example/src/client_example/count_and_save.py
+++ b/apps/examples/client-example/src/client_example/count_and_save.py
@@ -46,7 +46,7 @@ async def ensure_login(payload: None, context: EventContext, wildcard: str = '*'
     will execute using the client Bearer token.
 
     This example shows how to ensure both client and server apps can trust each other by having
-    installed their counterparts public keys on their running environments.
+    installed the counterpart's public key on their running environments.
     """
     auth_response = await app_call(
         "simple_example_auth_conn",

--- a/apps/examples/client-example/test/integration/test_it_count_and_save.py
+++ b/apps/examples/client-example/test/integration/test_it_count_and_save.py
@@ -1,22 +1,43 @@
-from typing import List, Type
+from dataclasses import dataclass
+from typing import List, Type, Union
 import pytest
 from base64 import b64encode
 
 from hopeit.app.context import EventContext
-from hopeit.dataobjects import EventPayload
+from hopeit.dataobjects import EventPayload, dataobject
+from hopeit.server.web import Unauthorized
 from hopeit.testing.apps import execute_event, create_test_context
 
 from model import Something, User, SomethingParams
 from client_example import CountAndSaveResult
 
 
+@dataobject
+@dataclass
+class MockAuthInfo:
+    access_token: str
+
+    @staticmethod
+    def mock_validate_token(token, context):
+        app, user = token.split(',')
+        return {
+            'app': app, 'user': user
+        }
+
+    @staticmethod
+    def mock_invalid_token(token, context):
+        return None
+
+
 async def custom_app_call(app_connection: str,
                           *, event: str, datatype: Type[str],
                           payload: EventPayload, context: EventContext,
-                          **kwargs) -> str:
+                          **kwargs) -> Union[str, MockAuthInfo]:
     if app_connection == "simple_example_conn" and event == "save_something":
         assert payload == SomethingParams(id="id2", user="test-user")
         return "test_path"
+    if app_connection == "simple_example_auth_conn" and event == "login":
+        return MockAuthInfo(access_token="test-app,test-user")
     raise NotImplementedError("Test case not implemented in mock_app_call")
 
 
@@ -38,6 +59,7 @@ async def test_query_item(monkeypatch, client_app_config):  # noqa: F811
     def mock_client_calls(module, context: EventContext):
         monkeypatch.setattr(module, "app_call", custom_app_call)
         monkeypatch.setattr(module, "app_call_list", custom_app_call_list)
+        monkeypatch.setattr(module.auth, "validate_token", MockAuthInfo.mock_validate_token)
 
     context = create_test_context(
         client_app_config, "count_and_save",
@@ -52,3 +74,25 @@ async def test_query_item(monkeypatch, client_app_config):  # noqa: F811
         mocks=[mock_client_calls])
 
     assert result == CountAndSaveResult(count=2, save_path='test_path')
+
+
+@pytest.mark.asyncio
+async def test_login_response_not_recognized(monkeypatch, client_app_config):  # noqa: F811
+
+    def mock_client_calls(module, context: EventContext):
+        monkeypatch.setattr(module, "app_call", custom_app_call)
+        monkeypatch.setattr(module, "app_call_list", custom_app_call_list)
+        monkeypatch.setattr(module.auth, "validate_token", MockAuthInfo.mock_invalid_token)
+
+    context = create_test_context(
+        client_app_config, "count_and_save",
+        auth_info={'payload': b64encode(b'test-user:test-password').decode()}
+    )
+
+    with pytest.raises(Unauthorized):
+        await execute_event(
+            app_config=client_app_config,
+            event_name='count_and_save',
+            payload=None,
+            context=context,
+            mocks=[mock_client_calls])

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1736,6 +1736,12 @@
           },
           "settings": {
             "type": "string"
+          },
+          "plugin_name": {
+            "type": "string"
+          },
+          "plugin_version": {
+            "type": "string"
           }
         },
         "x-module-name": "hopeit.app.config",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.9",
+    "version": "0.10",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/basic-auth/0x9/decode": {
+    "/api/basic-auth/0x10/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.0x9"
+          "basic_auth.0x10"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/config-manager/0x9/runtime-apps-config": {
+    "/api/config-manager/0x10/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -109,11 +109,11 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
-    "/api/config-manager/0x9/cluster-apps-config": {
+    "/api/config-manager/0x10/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -169,11 +169,11 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
-    "/api/simple-example/0x9/list-somethings": {
+    "/api/simple-example/0x10/list-somethings": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -243,7 +243,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -252,7 +252,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/query-something": {
+    "/api/simple-example/0x10/query-something": {
       "get": {
         "summary": "Simple Example: Query Something",
         "description": "Loads Something from disk",
@@ -329,7 +329,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -424,7 +424,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -433,7 +433,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/save-something": {
+    "/api/simple-example/0x10/save-something": {
       "post": {
         "summary": "Simple Example: Save Something",
         "description": "Creates and saves Something",
@@ -530,7 +530,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -539,7 +539,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/download-something": {
+    "/api/simple-example/0x10/download-something": {
       "get": {
         "summary": "Simple Example: Download Something",
         "description": "Download image file. The PostprocessHook return the requested file as stream.",
@@ -626,7 +626,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -635,7 +635,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/upload-something": {
+    "/api/simple-example/0x10/upload-something": {
       "post": {
         "summary": "Simple Example: Multipart Upload files",
         "description": "Upload files using Multipart form request",
@@ -773,7 +773,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -782,7 +782,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/streams/something-event": {
+    "/api/simple-example/0x10/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
         "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
@@ -851,7 +851,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -860,7 +860,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/collector/query-concurrently": {
+    "/api/simple-example/0x10/collector/query-concurrently": {
       "post": {
         "summary": "Simple Example: Query Concurrently",
         "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
@@ -932,7 +932,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -941,7 +941,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/collector/collect-spawn": {
+    "/api/simple-example/0x10/collector/collect-spawn": {
       "post": {
         "summary": "Simple Example: Collect and Spawn",
         "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
@@ -1019,7 +1019,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -1028,7 +1028,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/shuffle/spawn-event": {
+    "/api/simple-example/0x10/shuffle/spawn-event": {
       "post": {
         "summary": "Simple Example: Spawn Event",
         "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
@@ -1106,7 +1106,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -1115,7 +1115,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/shuffle/parallelize-event": {
+    "/api/simple-example/0x10/shuffle/parallelize-event": {
       "post": {
         "summary": "Simple Example: Parallelize Event",
         "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
@@ -1193,7 +1193,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -1202,7 +1202,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/basic-auth/0x9/login": {
+    "/api/simple-example/0x10/basic-auth/0x10/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -1270,7 +1270,7 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
@@ -1279,7 +1279,7 @@
         ]
       }
     },
-    "/api/simple-example/0x9/basic-auth/0x9/refresh": {
+    "/api/simple-example/0x10/basic-auth/0x10/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -1347,16 +1347,16 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
-            "simple_example.0x9.refresh": []
+            "simple_example.0x10.refresh": []
           }
         ]
       }
     },
-    "/api/simple-example/0x9/basic-auth/0x9/logout": {
+    "/api/simple-example/0x10/basic-auth/0x10/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -1433,11 +1433,11 @@
           }
         },
         "tags": [
-          "simple_example.0x9"
+          "simple_example.0x10"
         ],
         "security": [
           {
-            "simple_example.0x9.refresh": []
+            "simple_example.0x10.refresh": []
           }
         ]
       }
@@ -2073,7 +2073,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.9.4"
+            "default": "0.10.0"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -2330,10 +2330,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "simple_example.0x9.refresh": {
+      "simple_example.0x10.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "simple_example.0x9.refresh"
+        "name": "simple_example.0x10.refresh"
       }
     }
   },

--- a/docs/source/benchmark/dedicated.rst
+++ b/docs/source/benchmark/dedicated.rst
@@ -12,11 +12,11 @@ real time") for every request in the 99th percentile. The result is a rate (requ
 
 Three endpoints are evaluated in each test scenario
 
-* http://hostname:port/api/simple-benchmark/0x9/give-me-something retrieves information from objects randomly created
+* http://hostname:port/api/simple-benchmark/0x10/give-me-something retrieves information from objects randomly created
 
-* http://hostname:port/api/simple-benchmark/0x9/query-something-redis returns information from objects stored on a Redis server (memory store)
+* http://hostname:port/api/simple-benchmark/0x10/query-something-redis returns information from objects stored on a Redis server (memory store)
 
-* http://hostname:port/api/simple-benchmark/0x9/query-something-fs retrieves information from objects stored on a file system (SSD drive)
+* http://hostname:port/api/simple-benchmark/0x10/query-something-fs retrieves information from objects stored on a file system (SSD drive)
 
 Scenarios:
 __________
@@ -68,13 +68,13 @@ Now we are ready to start the simple-benchmark app to run the tests
 
 Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed starts into account) results:
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/give-me-something?item_id=string"
  p99 30.38ms @ 1794.29 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-redis?item_id=string"
  p99 27.18ms @ 1226.51 req/s
 
-./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c18 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-fs?item_id=string"
  p99 31.12ms @ 803.38 req/s
 
 2 . Docker, single/multiple instances of hopeit.engine
@@ -103,22 +103,22 @@ Latency (HdrHistogram - Uncorrected Latency, measured without taking delayed sta
 
 4 hopeit.engine instances behind a reverse proxy
 
-./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c40 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/give-me-something?item_id=string"
  p99 27.77ms @ 2587.95 req/s
 
-./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c32 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-redis?item_id=string"
  p99 28.67ms @ 1810.14 req/s
 
-./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x9/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c20 -d60s -R4000 --u_latency "http://localhost:8025/api/simple-benchmark/0x10/query-something-fs?item_id=string"
  p99 30.29ms @ 1241.39 req/s
 
 1 hopeit.engine instance
 
-./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/give-me-something?item_id=string"
+./wrk2/wrk -t8 -c34 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/give-me-something?item_id=string"
  p99 26.48ms @ 1336.18 req/s
 
-./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-redis?item_id=string"
+./wrk2/wrk -t6 -c24 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-redis?item_id=string"
  p99 29.14ms @ 908.93 req/s
 
-./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x9/query-something-fs?item_id=string"
+./wrk2/wrk -t4 -c14 -d60s -R4000 --u_latency "http://localhost:8021/api/simple-benchmark/0x10/query-something-fs?item_id=string"
  p99 24.77ms @ 624.77 req/s

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,26 @@
 Release Notes
 =============
 
+Version 0.10.0
+______________
+- Plugins:
+  - This release adds general support in several plugins to properly handle events that are plugged into app endpoints.
+
+  - Apps Client:
+    - Support for two authentication strategies: FORWARD_CONTEXT to propagate basic auth from client to server, and
+  CLIENT_APP_PUBLIC_KEY to create Bearer token to be validated by server.
+    - Added support to configure and call plugin events that are plugged into app endpoints (plug_mode=ON_APP)
+
+ - Config Manager:
+    - Returns effective_events section prefixing event names with app_key and plugin_key
+
+  - Apps Visualizer:
+    - Handles edges between client apps calling ON_APP plugged events
+
+- Engine:
+  - Added tracking in EventContext for app_key and plugin_key, allowing logging those details as extra fields. 
+
+
 Version 0.9.4
 _____________
 - Fix: `apps-visualizer` plugin load effective_events from `config-manager` to avoid need to install monitored apps in same

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -11,12 +11,13 @@ ______________
   CLIENT_APP_PUBLIC_KEY to create Bearer token to be validated by server.
     - Added support to configure and call plugin events that are plugged into app endpoints (plug_mode=ON_APP)
 
- - Config Manager:
+  - Config Manager:
     - Returns effective_events section prefixing event names with app_key and plugin_key
 
   - Apps Visualizer:
     - Handles edges between client apps calling ON_APP plugged events
     - Live stats considers IGNORED events as a warning status
+    - Fixed Open API warning for multiple schemas with same name
 
   - Log Streamer:
     - Support to capture IGNORED (Unathorized) event calls
@@ -27,8 +28,7 @@ ______________
 
 Version 0.9.4
 _____________
-- Fix: `apps-visualizer` plugin load effective_events from `config-manager` to avoid need to install monitored apps in same
-  running environment as `app-visualizer`
+- Fix: `apps-visualizer` plugin load effective_events from `config-manager` to avoid the need to install monitored apps in the same running environment as `apps-visualizer`
 - `config-manager` plugins, exposes effective_events (events with intermediate streams) as part of runtime app info.
 
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -16,6 +16,10 @@ ______________
 
   - Apps Visualizer:
     - Handles edges between client apps calling ON_APP plugged events
+    - Live stats considers IGNORED events as a warning status
+
+  - Log Streamer:
+    - Support to capture IGNORED (Unathorized) event calls
 
 - Engine:
   - Added tracking in EventContext for app_key and plugin_key, allowing logging those details as extra fields. 

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -173,6 +173,12 @@
         },
         "settings": {
           "type": "string"
+        },
+        "plugin_name": {
+          "type": "string"
+        },
+        "plugin_version": {
+          "type": "string"
         }
       },
       "description": "\n    AppConnections: metadata to initialize app client in order to connect\n    and issue requests to other running apps\n\n    :field: name, str: target app name to connect to\n    :field: version, str: target app version\n    :field: client, str: hopeit.app.client.Client class implementation, from available client plugins\n    :field: settings, optional str: key under `settings` section of app config containing connection configuration,\n        if not specified, plugin will lookup its default section usually the plugin name. But in case multiple\n        clients need to be configured, this value can be overridden.\n    "
@@ -482,7 +488,7 @@
         },
         "engine_version": {
           "type": "string",
-          "default": "0.9.0"
+          "default": "0.10.0"
         }
       },
       "description": "\n    Server configuration\n    "

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -38,7 +38,7 @@
     },
     "engine_version": {
       "type": "string",
-      "default": "0.9.0"
+      "default": "0.10.0"
     }
   },
   "description": "\n    Server configuration\n    ",

--- a/engine/src/hopeit/app/config.py
+++ b/engine/src/hopeit/app/config.py
@@ -353,6 +353,8 @@ class AppConnection:
     version: str
     client: str = "<<NO CLIENT CONFIGURED>>"
     settings: Optional[str] = None
+    plugin_name: Optional[str] = None
+    plugin_version: Optional[str] = None    
 
 
 @dataobject

--- a/engine/src/hopeit/app/config.py
+++ b/engine/src/hopeit/app/config.py
@@ -354,7 +354,7 @@ class AppConnection:
     client: str = "<<NO CLIENT CONFIGURED>>"
     settings: Optional[str] = None
     plugin_name: Optional[str] = None
-    plugin_version: Optional[str] = None    
+    plugin_version: Optional[str] = None
 
 
 @dataobject

--- a/engine/src/hopeit/app/context.py
+++ b/engine/src/hopeit/app/context.py
@@ -40,6 +40,7 @@ class EventContext:
                  track_ids: Dict[str, str],
                  auth_info: Dict[str, Any]):
         self.app_key: str = app_config.app_key()
+        self.plugin_key: str = plugin_config.app_key()
         self.app: AppDescriptor = app_config.app
         self.env: Env = {**plugin_config.env, **app_config.env}
         self.event_name = event_name
@@ -56,7 +57,12 @@ class EventContext:
               if self.event_info.type == EventType.STREAM
               else [])
         ]
-        self.track_ids = {k: track_ids[k] for k in track_fields if k in track_ids}
+        self.track_ids = {
+            k: track_ids[k] for k in track_fields if k in track_ids
+        }
+        self.track_ids['event.app'] = self.app_key
+        if self.plugin_key != self.app_key:
+            self.track_ids['event.plugin'] = self.plugin_key
 
 
 class PostprocessHook():

--- a/engine/src/hopeit/server/engine.py
+++ b/engine/src/hopeit/server/engine.py
@@ -82,7 +82,7 @@ class AppEngine:
         if self.stream_manager:
             await asyncio.sleep(self.app_config.engine.read_stream_timeout + 5)
             await self.stream_manager.close()
-        stop_app_connections(self.app_key)
+        await stop_app_connections(self.app_key)
         logger.info(__name__, f"Stopped app={self.app_key}")
 
     async def execute(self, *,

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.9.4"
+ENGINE_VERSION = "0.10.0"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/test/integration/test_it_logger.py
+++ b/engine/test/integration/test_it_logger.py
@@ -109,19 +109,19 @@ def test_get_app_logger(monkeypatch, mock_app_config):  # noqa: F811
         == "| INFO | mock_app test test_get_app_logger test_host test_pid | Test message " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
     logger.warning(_event_context(mock_app_config), "Test message")
     assert MockHandler.formatter.format(MockHandler.record)[24:] \
         == "| WARNING | mock_app test test_get_app_logger test_host test_pid | Test message " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
     logger.error(_event_context(mock_app_config), "Test message")
     assert MockHandler.formatter.format(MockHandler.record)[24:] \
         == "| ERROR | mock_app test test_get_app_logger test_host test_pid | Test message " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
 
 def test_app_logger_traceback(monkeypatch, mock_app_config):  # noqa: F811
@@ -132,21 +132,21 @@ def test_app_logger_traceback(monkeypatch, mock_app_config):  # noqa: F811
         == "| INFO | mock_app test test_get_app_logger test_host test_pid | Test for error " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id " \
+           "| track.session_id=test_session_id | event.app=mock_app.test " \
            "| trace=%5B%22AssertionError%3A%20Test%20for%20error%5Cn%22%5D"
     logger.warning(_event_context(mock_app_config), exc)
     assert MockHandler.formatter.format(MockHandler.record)[24:] \
         == "| WARNING | mock_app test test_get_app_logger test_host test_pid | Test for error " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id " \
+           "| track.session_id=test_session_id | event.app=mock_app.test " \
            "| trace=%5B%22AssertionError%3A%20Test%20for%20error%5Cn%22%5D"
     logger.error(_event_context(mock_app_config), exc)
     assert MockHandler.formatter.format(MockHandler.record)[24:] \
         == "| ERROR | mock_app test test_get_app_logger test_host test_pid | Test for error " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id " \
+           "| track.session_id=test_session_id | event.app=mock_app.test " \
            "| trace=%5B%22AssertionError%3A%20Test%20for%20error%5Cn%22%5D"
 
 
@@ -163,7 +163,7 @@ def test_get_app_logger_extra(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 | extra.field3=optional " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.warning(
         context,
@@ -176,7 +176,7 @@ def test_get_app_logger_extra(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 | extra.field3=optional " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.error(
         context,
@@ -188,7 +188,7 @@ def test_get_app_logger_extra(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 | extra.field3=optional " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     with pytest.raises(KeyError):
         logger.info(context, "Missing required field", extra=extra(field3='optional'))
@@ -207,7 +207,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.warning(
         context, "Log message",
@@ -218,7 +218,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.error(
         context, "Log message",
@@ -229,7 +229,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.start(
         context,
@@ -240,7 +240,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.done(
         context,
@@ -253,7 +253,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.ignored(
         context,
@@ -266,7 +266,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.failed(
         context,
@@ -279,7 +279,7 @@ def test_engine_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
 
 def test_engine_logger_no_context(monkeypatch, mock_app_config):  # noqa: F811
@@ -363,7 +363,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.warning(
         context, "Log message",
@@ -374,7 +374,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.error(
         context, "Log message",
@@ -385,7 +385,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.start(
         context,
@@ -396,7 +396,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.done(
         context,
@@ -409,7 +409,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.ignored(
         context,
@@ -422,7 +422,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
     logger.failed(
         context,
@@ -435,7 +435,7 @@ def test_engine_extra_logger(monkeypatch, mock_app_config):  # noqa: F811
            "| extra.field1=value1 | extra.field2=42 " \
            "| track.operation_id=test_operation_id " \
            "| track.request_id=test_request_id | track.request_ts=2020-01-01T00:00:00Z " \
-           "| track.session_id=test_session_id"
+           "| track.session_id=test_session_id | event.app=mock_app.test"
 
 
 def test_cli_logger(monkeypatch):  # noqa: F811

--- a/engine/test/mock_engine/__init__.py
+++ b/engine/test/mock_engine/__init__.py
@@ -25,11 +25,11 @@ class MockAppEngine(AppEngine):
 
     async def start(self):
         self.stream_manager = MockStreamManager(address="mock")
-        self.stream_manager.connect()
+        await self.stream_manager.connect()
         return self
 
     async def stop(self):
-        self.stream_manager.close()
+        await self.stream_manager.close()
 
 
 class MockEventHandler(EventHandler):

--- a/engine/test/unit/server/test_engine.py
+++ b/engine/test/unit/server/test_engine.py
@@ -170,7 +170,7 @@ async def test_read_write_stream_auto_queue(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     engine = await create_engine(app_config=mock_app_config, plugin=mock_plugin_config)
@@ -196,7 +196,7 @@ async def test_read_write_stream_propagate_queue(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'custom')
@@ -225,7 +225,7 @@ async def test_read_write_stream_drop_queue(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'custom')
@@ -254,7 +254,7 @@ async def test_read_write_stream_new_queue(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     mock_app_config.events['mock_read_write_stream'].write_stream.queues = \
@@ -282,7 +282,7 @@ async def test_read_write_stream_new_queue_propagate_auto(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     mock_app_config.events['mock_read_write_stream'].write_stream.queues = \
@@ -312,7 +312,7 @@ async def test_read_write_stream_new_queue_propagate(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'original')
@@ -343,7 +343,7 @@ async def test_read_write_stream_new_queue_drop(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'original')
@@ -374,7 +374,7 @@ async def test_read_write_stream_multiple_queues(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'original')
@@ -415,7 +415,7 @@ async def test_read_write_stream_multiple_queues_propagate(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', None)  # Will use last part of stream name
@@ -458,7 +458,7 @@ async def test_read_write_stream_multiple_queues_propagate_AUTO(
         'track.operation_id': 'test_operation_id', 'track.request_id': 'test_request_id',
         'track.request_ts': '2020-02-05T17:07:37.771396+00:00', 'track.session_id': 'test_session_id',
         'stream.name': 'test_stream', 'stream.msg_id': '0000000000-0',
-        'stream.consumer_group': 'test_group'
+        'stream.consumer_group': 'test_group', 'event.app': 'mock_app.test'
     })
     monkeypatch.setattr(MockStreamManager, 'test_payload', payload)
     monkeypatch.setattr(MockStreamManager, 'test_queue', 'custom')

--- a/engine/test/unit/testing/test_apps.py
+++ b/engine/test/unit/testing/test_apps.py
@@ -34,7 +34,8 @@ def test_create_test_context(mock_app_config):  # noqa: F811
             'track.operation_id': 'test_operation_id',
             'track.request_id': 'test_request_id',
             'track.request_ts': result.track_ids['track.request_ts'],
-            'track.session_id': ''
+            'track.session_id': '',
+            'event.app': 'mock_app.test'
     }
     assert result.auth_info == {'auth_type': AuthType.UNSECURED, 'allowed': 'true'}
 

--- a/plugins/auth/basic-auth/setup.py
+++ b/plugins/auth/basic-auth/setup.py
@@ -6,7 +6,7 @@ with open("../../../engine/src/hopeit/server/version.py") as fp:
     exec(fp.read(), version)
 
 setuptools.setup(
-    name="hopeit.plugins.basic_auth",
+    name="hopeit.basic_auth",
     version=version['ENGINE_VERSION'],
     description="Hopeit.py Basic Auth Plugin",
     package_dir={
@@ -21,7 +21,7 @@ setuptools.setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "hopeit.engine",
+        f"hopeit.engine=={version['ENGINE_VERSION']}",
         "PyJWT[crypto]>=1.7.1,<2"
     ],
     extras_require={

--- a/plugins/clients/apps-client/src/hopeit/apps_client/__init__.py
+++ b/plugins/clients/apps-client/src/hopeit/apps_client/__init__.py
@@ -2,6 +2,7 @@
 Client to invoke events in configured connected Apps
 """
 from contextlib import AbstractAsyncContextManager
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Type
 import asyncio
 from collections import defaultdict
@@ -26,6 +27,19 @@ from hopeit.server.api import app_route_name
 logger, extra = engine_extra_logger()
 
 
+class ClientAuthStrategy(str, Enum):
+    """
+    Supported clients auth strategy:
+
+    CLIENT_APP_PUBLIC_KEY: Creates a Bearer token using client app private key. To allow access on service
+        side, client app public key must be available for the called app.
+    FORWARDS_CONTEXT: Build Authorization header based on what's available in event context auth_info.
+        This strategy can be used to propagate Basic auth from client to called service.
+    """
+    CLIENT_APP_PUBLIC_KEY = "CLIENT_APP_PUBLIC_KEY"
+    FORWARD_CONTEXT = "FORWARD_CONTEXT"
+
+
 @dataobject
 @dataclass
 class AppsClientSettings:
@@ -45,6 +59,7 @@ class AppsClientSettings:
     max_connections: int = 100
     max_connections_per_host: int = 0
     dns_cache_ttl: int = 10
+    auth_strategy: ClientAuthStrategy = ClientAuthStrategy.CLIENT_APP_PUBLIC_KEY
     routes_override: Dict[str, str] = field(default_factory=dict)
 
 
@@ -168,8 +183,14 @@ class AppsClient(Client):
             name=self.app_connection.name,
             version=self.app_connection.version
         )
+        plugin_descriptor = None
+        if self.app_connection.plugin_name:
+            plugin_descriptor = AppDescriptor(
+                name=self.app_connection.plugin_name,
+                version=self.app_connection.plugin_version
+            )
         return app_route_name(
-            app_descriptor, event_name=event_name,
+            app_descriptor, event_name=event_name, plugin=plugin_descriptor,
             override_route_name=self.settings.routes_override.get(event_name)
         )
 
@@ -183,7 +204,8 @@ class AppsClient(Client):
         ))
         self._register_event_connections()
         self._create_session()
-        self._ensure_token(self._now_ts())
+        if self.settings.auth_strategy == ClientAuthStrategy.CLIENT_APP_PUBLIC_KEY:
+            self._ensure_token(self._now_ts())
         logger.info(__name__, "Client ready.", extra=extra(
             app=self.app_key, app_connection=self.app_conn_key
         ))
@@ -229,9 +251,11 @@ class AppsClient(Client):
             raise RuntimeError("AppsClient not started: `client.start()` must be called from engine.")
         now_ts = self._now_ts()
         event_info = self._get_event_connection(context, event_name)
-        token = self._ensure_token(now_ts)
-        headers = self._request_headers(context, token)
-
+        headers = {
+            **self._request_headers(context),
+            **self._auth_headers(context, now_ts=now_ts)
+        }
+        
         for retry_count in range(self.settings.retries + 1):
             host_index = self._next_available_host(self.conn_state, now_ts, context)
             host = self.conn_state.load_balancer.host(host_index)
@@ -335,7 +359,7 @@ class AppsClient(Client):
             load_balancer=lb
         )
 
-    def _request_headers(self, context: EventContext, token: str):
+    def _request_headers(self, context: EventContext):
         return {
             **{
                 f"x-{spinalcase(k)}": str(v)
@@ -343,9 +367,23 @@ class AppsClient(Client):
             },
             "x-track-client-app-key": context.app_key,
             "x-track-client-event-name": context.event_name,
-            "authorization": f"Bearer {token}",
             "content-type": "application/json"
         }
+
+    def _auth_headers(self, context: EventContext, now_ts: int):
+        if self.settings.auth_strategy == ClientAuthStrategy.CLIENT_APP_PUBLIC_KEY:
+            token = self._ensure_token(now_ts)
+            return {
+                "authorization": f"Bearer {token}"
+            }
+        
+        if self.settings.auth_strategy == ClientAuthStrategy.FORWARD_CONTEXT:
+            return {
+                "authorization": f"{context.auth_info['auth_type'].value} {context.auth_info['payload']}"
+            }
+        
+        return {}
+
 
     async def _parse_response(self, response, context: EventContext,
                               datatype: Type[EventPayloadType],

--- a/plugins/clients/apps-client/test/unit/conftest.py
+++ b/plugins/clients/apps-client/test/unit/conftest.py
@@ -1,4 +1,4 @@
-from hopeit.apps_client import AppsClientSettings
+from hopeit.apps_client import AppsClientSettings, ClientAuthStrategy
 import pytest
 
 from hopeit.app.config import AppConfig, AppConnection, AppDescriptor, AppEngineConfig, \
@@ -23,11 +23,22 @@ def mock_client_app_config():
                 name="test_app",
                 version=APPS_API_VERSION,
                 client="hopeit.apps_client.AppsClient"
+            ),
+            "test_app_plugin_connection": AppConnection(
+                name="test_app",
+                version=APPS_API_VERSION,
+                client="hopeit.apps_client.AppsClient",
+                plugin_name="test_plugin",
+                plugin_version=APPS_API_VERSION
             )
         },
         settings={
             "test_app_connection": Payload.to_obj(AppsClientSettings(
                 connection_str="http://test-host1,http://test-host2"
+            )),
+            "test_app_plugin_connection": Payload.to_obj(AppsClientSettings(
+                connection_str="http://test-host1,http://test-host2",
+                auth_strategy=ClientAuthStrategy.FORWARD_CONTEXT
             ))
         },
         events={
@@ -43,6 +54,11 @@ def mock_client_app_config():
                         app_connection="test_app_connection",
                         event="test_event_post",
                         type=EventConnectionType.POST
+                    ),
+                    EventConnection(
+                        app_connection="test_app_plugin_connection",
+                        event="test_event_plugin",
+                        type=EventConnectionType.GET
                     )
                 ]
             )
@@ -58,5 +74,5 @@ def mock_client_app_config():
 def mock_auth(mocker):
     auth_mock = mocker.MagicMock()
     auth_mock.new_token = mocker.MagicMock()
-    auth_mock.new_token.return_value = "test_token"
+    auth_mock.new_token.return_value = "test-token"
     return auth_mock

--- a/plugins/clients/apps-client/test/unit/test_apps_client.py
+++ b/plugins/clients/apps-client/test/unit/test_apps_client.py
@@ -33,7 +33,6 @@ async def test_client_get(monkeypatch, mock_client_app_config, mock_auth):
         )
 
 
-
 @pytest.mark.asyncio
 async def test_client_app_plugin(monkeypatch, mock_client_app_config, mock_auth):
     async with MockClientSession.lock:

--- a/plugins/clients/apps-client/test/unit/test_apps_client.py
+++ b/plugins/clients/apps-client/test/unit/test_apps_client.py
@@ -7,9 +7,11 @@ from hopeit.apps_client import AppsClientException, ClientLoadBalancerException
 from hopeit.app.client import AppConnectionNotFound, app_call, app_call_list, app_client
 from hopeit.app.config import AppConfig
 from hopeit.app.errors import Unauthorized
+from hopeit.server.config import AuthType
 from hopeit.testing.apps import create_test_context
 
-from . import MockClientSession, MockPayloadData, MockResponseData, init_mock_client_app
+from . import MockClientSession, MockPayloadData, MockResponseData, \
+    init_mock_client_app, init_mock_client_app_plugin
 
 
 @pytest.mark.asyncio
@@ -21,6 +23,31 @@ async def test_client_get(monkeypatch, mock_client_app_config, mock_auth):
         context = create_test_context(mock_client_app_config, "mock_client_event")
         result = await app_call(
             "test_app_connection", event="test_event_get",
+            datatype=MockResponseData, payload=None, context=context,
+            test_param="test_param_value"
+        )
+        assert result == MockResponseData(
+            value="ok", param="test_param_value",
+            host="http://test-host1",
+            log={"http://test-host1": 1}
+        )
+
+
+
+@pytest.mark.asyncio
+async def test_client_app_plugin(monkeypatch, mock_client_app_config, mock_auth):
+    async with MockClientSession.lock:
+        await init_mock_client_app_plugin(
+            apps_client_module, monkeypatch, mock_auth, mock_client_app_config,
+            "test-plugin", "test-event-plugin", "ok"
+        )
+        context = create_test_context(mock_client_app_config, "mock_client_event")
+        context.auth_info = {
+            "auth_type": AuthType.BASIC,
+            "payload": "user:pass"
+        }
+        result = await app_call(
+            "test_app_plugin_connection", event="test_event_plugin",
             datatype=MockResponseData, payload=None, context=context,
             test_param="test_param_value"
         )

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -1087,22 +1087,40 @@
         "x-module-name": "hopeit.apps_visualizer.site.visualization",
         "description": "VisualizationOptions(app_prefix: str = '', host_filter: str = '', expanded_view: bool = False, live: bool = False)"
       },
+      "CytoscapeGraph": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            },
+            "default": {}
+          }
+        },
+        "x-module-name": "hopeit.apps_visualizer.site.visualization",
+        "description": "CytoscapeGraph(data: Dict[str, Dict[str, Any]] = <factory>)"
+      },
       "EventsGraphResult": {
         "type": "object",
         "required": [
           "runtime_apps",
+          "graph",
           "options"
         ],
         "properties": {
           "runtime_apps": {
             "$ref": "#/components/schemas/RuntimeApps"
           },
+          "graph": {
+            "$ref": "#/components/schemas/CytoscapeGraph"
+          },
           "options": {
             "$ref": "#/components/schemas/VisualizationOptions"
           }
         },
-        "x-module-name": "hopeit.apps_visualizer.site.main",
-        "description": "EventsGraphResult(runtime_apps: hopeit.config_manager.RuntimeApps, options: hopeit.apps_visualizer.site.visualization.VisualizationOptions)"
+        "x-module-name": "hopeit.apps_visualizer.apps.events_graph",
+        "description": "EventsGraphResult(runtime_apps: hopeit.config_manager.RuntimeApps, graph: hopeit.apps_visualizer.site.visualization.CytoscapeGraph, options: hopeit.apps_visualizer.site.visualization.VisualizationOptions)"
       }
     },
     "securitySchemes": {

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -601,6 +601,12 @@
           },
           "settings": {
             "type": "string"
+          },
+          "plugin_name": {
+            "type": "string"
+          },
+          "plugin_version": {
+            "type": "string"
           }
         },
         "x-module-name": "hopeit.app.config",

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.9",
+    "version": "0.10",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/config-manager/0x9/runtime-apps-config": {
+    "/api/config-manager/0x10/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
-    "/api/config-manager/0x9/cluster-apps-config": {
+    "/api/config-manager/0x10/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,7 +122,7 @@
           }
         },
         "tags": [
-          "config_manager.0x9"
+          "config_manager.0x10"
         ]
       }
     },
@@ -209,11 +209,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x9"
+          "apps_visualizer.0x10"
         ]
       }
     },
-    "/api/apps-visualizer/0x9/apps/events-graph": {
+    "/api/apps-visualizer/0x10/apps/events-graph": {
       "get": {
         "summary": "App Visualizer: Events Graph Data",
         "description": "App Visualizer: Events Graph Data",
@@ -287,11 +287,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x9"
+          "apps_visualizer.0x10"
         ]
       }
     },
-    "/api/apps-visualizer/0x9/event-stats/live": {
+    "/api/apps-visualizer/0x10/event-stats/live": {
       "get": {
         "summary": "App Visualizer: Live Stats",
         "description": "App Visualizer: Live Stats",
@@ -365,7 +365,7 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x9"
+          "apps_visualizer.0x10"
         ]
       }
     }
@@ -938,7 +938,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.9.4"
+            "default": "0.10.0"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
@@ -2,10 +2,8 @@
 Events graph showing events, stream and dependencies for specified apps
 """
 from typing import Optional
-from hopeit.app.config import EventDescriptor, EventPlugMode
 
 from hopeit.app.context import EventContext
-
 from hopeit.app.api import event_api
 from hopeit.dataobjects import dataclass, dataobject
 from hopeit.app.events import collector_step, Collector

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
@@ -72,12 +72,6 @@ def _filter_hosts(runtime_info: RuntimeAppInfo, options: VisualizationOptions) -
         )
     )
 
-def _event_name(app_key: str, app_info, event_name: str, event_info: EventDescriptor) -> str:
-    if event_info.plug_mode == EventPlugMode.ON_APP:
-        return f"{app_key}.{event_name}!!!!!"
-    return f"{app_key}.{event_name}"
-
-
 
 async def config_graph(collector: Collector, context: EventContext) -> Optional[Graph]:
     """
@@ -93,8 +87,8 @@ async def config_graph(collector: Collector, context: EventContext) -> Optional[
     ]
 
     events = {
-        _event_name(app_key, app_info, event_name, event_info): event_info
-        for app_key, app_info in filtered_apps
+        event_name: event_info
+        for _, app_info in filtered_apps
         for event_name, event_info in app_info.effective_events.items()
     }
 

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/apps/events_graph.py
@@ -2,6 +2,7 @@
 Events graph showing events, stream and dependencies for specified apps
 """
 from typing import Optional
+from hopeit.app.config import EventDescriptor, EventPlugMode
 
 from hopeit.app.context import EventContext
 
@@ -71,6 +72,12 @@ def _filter_hosts(runtime_info: RuntimeAppInfo, options: VisualizationOptions) -
         )
     )
 
+def _event_name(app_key: str, app_info, event_name: str, event_info: EventDescriptor) -> str:
+    if event_info.plug_mode == EventPlugMode.ON_APP:
+        return f"{app_key}.{event_name}!!!!!"
+    return f"{app_key}.{event_name}"
+
+
 
 async def config_graph(collector: Collector, context: EventContext) -> Optional[Graph]:
     """
@@ -86,7 +93,7 @@ async def config_graph(collector: Collector, context: EventContext) -> Optional[
     ]
 
     events = {
-        f"{app_key}.{event_name}": event_info
+        _event_name(app_key, app_info, event_name, event_info): event_info
         for app_key, app_info in filtered_apps
         for event_name, event_info in app_info.effective_events.items()
     }

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
@@ -49,8 +49,11 @@ def get_stats(host_pids: Set[Tuple[str, str]], time_window_secs: int, recent_sec
     recent_ts = (now_ts - timedelta(seconds=recent_secs)).strftime("%Y-%m-%d %H:%M:%S")
     for entry in recent_entries:
         if entry.ts >= from_ts and (entry.host, entry.pid) in host_pids:
-            event_name = entry.extra.get("stream.event_name", entry.event_name)
-            event_name = f"{auto_path(entry.app_name, entry.app_version)}.{event_name}"
+            event_name = entry.extra.get("event.app", auto_path(entry.app_name, entry.app_version)) + '.'
+            plugin = entry.extra.get("event.plugin")
+            if plugin:
+                event_name += plugin + '.'
+            event_name += entry.extra.get("stream.event_name", entry.event_name)
             event_stats = stats[event_name]
             stream_key = ">" + entry.extra.get("stream.name", "NA")
             stream_queue = "." + entry.extra.get("stream.queue", "")

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/collect.py
@@ -18,11 +18,12 @@ class EventStats:
     started: int = 0
     done: int = 0
     failed: int = 0
+    ignored: int = 0
     recent: int = 0
 
     @property
     def pending(self):
-        return max(0, self.started - self.done - self.failed)
+        return max(0, self.started - self.done - self.failed - self.ignored)
 
 
 recent_entries: Deque[LogEntry] = deque(maxlen=2000)
@@ -71,6 +72,9 @@ def get_stats(host_pids: Set[Tuple[str, str]], time_window_secs: int, recent_sec
             elif entry.msg == "FAILED":
                 event_stats.failed += 1
                 stream_stats.failed += 1
+            elif entry.msg == "IGNORED":
+                event_stats.ignored += 1
+                stream_stats.ignored += 1
             if entry.ts >= recent_ts:
                 event_stats.recent += 1
                 stream_stats.recent += 1

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/live.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/event_stats/live.py
@@ -80,6 +80,8 @@ async def live_stats(collector: Collector, context: EventContext) -> Collector:
                     classes.append('RECENT')
                 if s.failed:
                     classes.append('FAILED')
+                if s.ignored:
+                    classes.append('IGNORED')
                 item['classes'] = _classes(item, classes)
                 target = item['data'].get('target', ' ')
                 if target[0] == '>':

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/graphs/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/graphs/__init__.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 from hopeit.dataobjects import dataobject
 from hopeit.app.config import AppConnection, AppDescriptor, EventDescriptor, EventType, StreamQueueStrategy
+from hopeit.server.names import auto_path
 
 
 class NodeType(Enum):
@@ -126,7 +127,11 @@ def add_app_connections(nodes: Dict[str, Node], *,
             for conn in event_info.connections:
                 app_connection = app_connections[f"{app_key}.{conn.app_connection}"]
                 target_app_key = AppDescriptor(name=app_connection.name, version=app_connection.version).app_key()
-                dest_node = nodes.get(f"{target_app_key}.{conn.event}.{conn.type.value}")
+                dest_node_name = f"{target_app_key}."
+                if app_connection.plugin_name:
+                    dest_node_name += auto_path(app_connection.plugin_name, app_connection.plugin_version) + '.'
+                dest_node_name += f"{conn.event}.{conn.type.value}"
+                dest_node = nodes.get(dest_node_name)
                 if dest_node:
                     port = f"{event_name}.{app_connection.name}.{conn.event}.{conn.type.value}"
                     source_node.outputs.append(port)

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/graphs/__init__.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/graphs/__init__.py
@@ -129,7 +129,10 @@ def add_app_connections(nodes: Dict[str, Node], *,
                 target_app_key = AppDescriptor(name=app_connection.name, version=app_connection.version).app_key()
                 dest_node_name = f"{target_app_key}."
                 if app_connection.plugin_name:
-                    dest_node_name += auto_path(app_connection.plugin_name, app_connection.plugin_version) + '.'
+                    dest_node_name += auto_path(
+                        app_connection.plugin_name,
+                        app_connection.plugin_version or app_connection.version
+                    ) + '.'
                 dest_node_name += f"{conn.event}.{conn.type.value}"
                 dest_node = nodes.get(dest_node_name)
                 if dest_node:

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
@@ -334,6 +334,12 @@
           },
         },
         {
+          selector: "node.EVENT.IGNORED",
+          style: {
+            "background-color": "#FFEEAA",
+          },
+        },
+        {
           selector: "node.EVENT.PENDING",
           style: {
             "background-color": "#AAFFFF",

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/main.py
@@ -33,30 +33,24 @@ __api__ = event_api(
 _dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
 
-# @dataobject
-# @dataclass
-# class RuntimeApps:
-#     apps: List[AppConfig]
-
-
 @dataobject
 @dataclass
-class EventsGraphResult:
+class RuntimeAppsConfig:
     runtime_apps: RuntimeApps
     options: VisualizationOptions
 
 
-async def runtime_apps_config(options: VisualizationOptions, context: EventContext) -> EventsGraphResult:
+async def runtime_apps_config(options: VisualizationOptions, context: EventContext) -> RuntimeAppsConfig:
     """
     Extract current runtime app_config objects
     """
-    return EventsGraphResult(
+    return RuntimeAppsConfig(
         runtime_apps=await get_runtime_apps(context, refresh=True, expand_events=options.expanded_view),
         options=options
     )
 
 
-async def __postprocess__(result: EventsGraphResult, context: EventContext, response: PostprocessHook) -> str:
+async def __postprocess__(result: RuntimeAppsConfig, context: EventContext, response: PostprocessHook) -> str:
     """
     Renders html from template, using cytospace data json
     """

--- a/plugins/ops/apps-visualizer/test/integration/__init__.py
+++ b/plugins/ops/apps-visualizer/test/integration/__init__.py
@@ -1,4 +1,6 @@
-from hopeit.app.config import AppConfig
+from typing import Dict
+from hopeit.app.config import AppConfig, EventDescriptor
+from hopeit.dataobjects.payload import Payload
 from hopeit.server.version import APPS_API_VERSION, APPS_ROUTE_VERSION
 from hopeit.server import config as server_config
 from hopeit.testing.apps import config
@@ -10,6 +12,7 @@ from hopeit.apps_visualizer import apps
 class MockAppEngine:
     def __init__(self, app_config: AppConfig):
         self.app_config = app_config
+        self.effective_events: Dict[str, EventDescriptor] = {}
 
 
 class MockServer:
@@ -32,15 +35,15 @@ def mock_getenv(var_name):
     raise NotImplementedError(var_name)
 
 
-def mock_runtime(monkeypatch):
+def mock_runtime(monkeypatch, effective_events):
     setattr(apps, "_expire", 0.0)
     monkeypatch.setattr(server_config.os, 'getenv', mock_getenv)
     app_config = config('apps/examples/simple-example/config/app-config.json')
+    basic_auth_config = config('plugins/auth/basic-auth/config/plugin-config.json')
     client_app_config = config('apps/examples/client-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(
-            app_config, client_app_config
+    server = MockServer(basic_auth_config, app_config, client_app_config)
+    for app_key, app_effective_events in effective_events.items():
+        server.app_engines[app_key].effective_events = Payload.from_obj(
+            app_effective_events, datatype=dict, item_datatype=EventDescriptor
         )
-    )
+    monkeypatch.setattr(runtime, "server", server)

--- a/plugins/ops/apps-visualizer/test/integration/conftest.py
+++ b/plugins/ops/apps-visualizer/test/integration/conftest.py
@@ -38,6 +38,13 @@ def events_graph_data_expanded():
         return json.loads(json_str)
 
 
+@pytest.fixture
+def effective_events():
+    with open(Path(os.path.dirname(os.path.realpath(__file__))) / 'effective_events.json') as f:
+        json_str = f.read().replace("${APPS_ROUTE_VERSION}", APPS_ROUTE_VERSION)
+        return json.loads(json_str)
+
+
 async def _process_log_entries(raw: LogRawBatch) -> LogBatch:
     plugin_config = config('plugins/ops/log-streamer/config/plugin-config.json')
     return await execute_event(plugin_config, "log_reader", payload=raw)  # type: ignore
@@ -56,10 +63,14 @@ async def log_entries() -> LogBatch:
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} save_something host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
         f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} service.something_generator host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event | stream.queue=AUTO",  # noqa: E501
+        f"2021-06-02 18:01:44,290 | INFO | client-example {APPS_API_VERSION} count_and_save host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
+        f"2021-06-02 18:01:44,303 | INFO | client-example {APPS_API_VERSION} count_and_save host 17031 | IGNORED | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test",  # noqa: E501
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
         f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.something_event host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
         f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
         f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} streams.process_events host 17031 | FAILED | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test |  stream.name=simple_example.{APPS_ROUTE_VERSION}.streams.something_event.high-prio | stream.queue=high-prio",  # noqa: E501
+        f"2021-06-02 18:01:44,290 | INFO | simple-example {APPS_API_VERSION} login host 17031 | START | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | event.app=simple_example.{APPS_ROUTE_VERSION} | event.plugin=basic_auth.{APPS_ROUTE_VERSION}",  # noqa: E501
+        f"2021-06-02 18:01:44,303 | INFO | simple-example {APPS_API_VERSION} login host 17031 | DONE | response.status=404 | metrics.duration=13.057 | track.operation_id=f2659a30-5ac4-4dd4-b1f7-9a00db0bf7d5 | track.request_id=7ee59fa7-c1e4-4a60-a79b-a25dbbd6cb82 | track.request_ts=2021-06-02T18:01:44.289394+00:00 | track.caller=test | track.session_id=test | event.app=simple_example.{APPS_ROUTE_VERSION} | event.plugin=basic_auth.{APPS_ROUTE_VERSION}",  # noqa: E501
     ])
     batch = await _process_log_entries(raw)
     ts = datetime.now()

--- a/plugins/ops/apps-visualizer/test/integration/effective_events.json
+++ b/plugins/ops/apps-visualizer/test/integration/effective_events.json
@@ -1,0 +1,813 @@
+{
+  "simple_example.${APPS_ROUTE_VERSION}": {
+    "login": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Basic"
+      ]
+    },
+    "refresh": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Refresh"
+      ]
+    },
+    "logout": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Refresh"
+      ]
+    },
+    "list_somethings": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "query_something": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "route": "simple-example/0.10/query_something",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "query_something_extended": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "route": "simple-example/0.10/query_something",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "save_something": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "download_something": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "upload_something": {
+      "type": "MULTIPART",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "service.something_generator": {
+      "type": "SERVICE",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "DROP"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 10,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "streams.something_event": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "queues": [
+          "high-prio"
+        ],
+        "queue_strategy": "DROP"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "streams.process_events": {
+      "type": "STREAM",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "read_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "consumer_group": "streams.process_events",
+        "queues": [
+          "high-prio",
+          "AUTO"
+        ]
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group",
+            "stream.event_id",
+            "stream.event_ts",
+            "stream.submit_ts",
+            "stream.read_ts"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 5,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "collector.query_concurrently": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "collector.collect_spawn": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "PROPAGATE"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "collector.collect_spawn$spawn": {
+      "type": "STREAM",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "read_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
+        "consumer_group": "collector.collect_spawn.spawn",
+        "queues": [
+          "AUTO"
+        ]
+      },
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "DROP"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "shuffle.spawn_event": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "PROPAGATE"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "shuffle.spawn_event$update_status": {
+      "type": "STREAM",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "read_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
+        "consumer_group": "shuffle.spawn_event.update_status",
+        "queues": [
+          "AUTO"
+        ]
+      },
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "DROP"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "shuffle.parallelize_event": {
+      "type": "POST",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "PROPAGATE"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "shuffle.parallelize_event$process_first_part": {
+      "type": "STREAM",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "read_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
+        "consumer_group": "shuffle.parallelize_event.process_first_part",
+        "queues": [
+          "AUTO"
+        ]
+      },
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "PROPAGATE"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    },
+    "shuffle.parallelize_event$update_status": {
+      "type": "STREAM",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "read_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
+        "consumer_group": "shuffle.parallelize_event.update_status",
+        "queues": [
+          "AUTO"
+        ]
+      },
+      "write_stream": {
+        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+        "queues": [
+          "AUTO"
+        ],
+        "queue_strategy": "DROP"
+      },
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [
+            "something_id"
+          ],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 1000,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": []
+    }
+  },
+  "client_example.${APPS_ROUTE_VERSION}": {
+    "count_and_save": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "connections": [
+        {
+          "app_connection": "simple_example_auth_conn",
+          "event": "login",
+          "type": "GET"
+        },
+        {
+          "app_connection": "simple_example_conn",
+          "event": "list_somethings",
+          "type": "GET"
+        },
+        {
+          "app_connection": "simple_example_conn",
+          "event": "save_something",
+          "type": "POST"
+        }
+      ],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Basic"
+      ]
+    }
+  },
+  "basic_auth.${APPS_ROUTE_VERSION}": {
+    "login": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Basic"
+      ]
+    },
+    "refresh": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Refresh"
+      ]
+    },
+    "logout": {
+      "type": "GET",
+      "plug_mode": "OnApp",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Refresh"
+      ]
+    },
+    "decode": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "connections": [],
+      "config": {
+        "response_timeout": 60,
+        "logging": {
+          "extra_fields": [],
+          "stream_fields": [
+            "stream.name",
+            "stream.msg_id",
+            "stream.consumer_group"
+          ]
+        },
+        "stream": {
+          "timeout": 60,
+          "target_max_len": 0,
+          "throttle_ms": 0,
+          "step_delay": 0,
+          "batch_size": 100,
+          "compression": "lz4",
+          "serialization": "json+base64"
+        }
+      },
+      "auth": [
+        "Bearer"
+      ]
+    }
+  }
+}

--- a/plugins/ops/apps-visualizer/test/integration/events_graph_data_expanded.json
+++ b/plugins/ops/apps-visualizer/test/integration/events_graph_data_expanded.json
@@ -1,4 +1,60 @@
 {
+  "basic_auth.${APPS_ROUTE_VERSION}.decode.GET": {
+    "data": {
+      "id": "basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "content": "GET"
+    },
+    "classes": "REQUEST"
+  },
+  "basic_auth.${APPS_ROUTE_VERSION}.decode": {
+    "data": {
+      "id": "basic_auth.${APPS_ROUTE_VERSION}.decode",
+      "content": "basic_auth.${APPS_ROUTE_VERSION}\ndecode"
+    },
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "content": "GET"
+    },
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.login"
+    },
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "content": "GET"
+    },
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.refresh"
+    },
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "content": "GET"
+    },
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.logout"
+    },
+    "classes": "EVENT"
+  },
   "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
     "data": {
       "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
@@ -251,6 +307,38 @@
     },
     "classes": "EVENT"
   },
+  "edge_basic_auth.${APPS_ROUTE_VERSION}.decode.GET": {
+    "data": {
+      "id": "edge_basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "source": "basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "target": "basic_auth.${APPS_ROUTE_VERSION}.decode",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout",
+      "label": ""
+    }
+  },
   "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
     "data": {
       "id": "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
@@ -464,6 +552,14 @@
       "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
       "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
       "target": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "label": ""
+    }
+  },
+  "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.login.GET": {
+    "data": {
+      "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.login.GET",
+      "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
       "label": ""
     }
   },

--- a/plugins/ops/apps-visualizer/test/integration/events_graph_data_standard.json
+++ b/plugins/ops/apps-visualizer/test/integration/events_graph_data_standard.json
@@ -1,359 +1,455 @@
 {
-    "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
-        "content": "GET"
-      },
-      "classes": "REQUEST"
+  "basic_auth.${APPS_ROUTE_VERSION}.decode.GET": {
+    "data": {
+      "id": "basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nlist_somethings"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "basic_auth.${APPS_ROUTE_VERSION}.decode": {
+    "data": {
+      "id": "basic_auth.${APPS_ROUTE_VERSION}.decode",
+      "content": "basic_auth.${APPS_ROUTE_VERSION}\ndecode"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
-        "content": "GET"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.query_something": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.query_something",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.login"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something_extended"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.refresh"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.save_something": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.save_something",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nsave_something"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nbasic_auth.${APPS_ROUTE_VERSION}.logout"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
-        "content": "GET"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.download_something": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.download_something",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\ndownload_something"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nlist_somethings"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
-        "content": "MULTIPART"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nupload_something"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.query_something": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something"
     },
-    ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
-      "data": {
-        "id": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
-      },
-      "classes": "STREAM"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
+      "content": "POST"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nservice.something_generator"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nquery_something_extended"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "content": "POST"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.save_something": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.save_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nsave_something"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.process_events"
-      },
-      "classes": "EVENT"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
+      "content": "GET"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.download_something": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.download_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ndownload_something"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.query_concurrently"
-      },
-      "classes": "EVENT"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
+      "content": "MULTIPART"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nupload_something"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.collect_spawn"
-      },
-      "classes": "EVENT"
+    "classes": "EVENT"
+  },
+  ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
+    "data": {
+      "id": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "STREAM"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nservice.something_generator"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.spawn_event"
-      },
-      "classes": "EVENT"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
+      "content": "POST"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
-        "content": "POST"
-      },
-      "classes": "REQUEST"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.something_event"
     },
-    "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
-      "data": {
-        "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
-        "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event"
-      },
-      "classes": "EVENT"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nstreams.process_events"
     },
-    "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET": {
-      "data": {
-        "id": "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
-        "content": "GET"
-      },
-      "classes": "REQUEST"
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
+      "content": "POST"
     },
-    "client_example.${APPS_ROUTE_VERSION}.count_and_save": {
-      "data": {
-        "id": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
-        "content": "client_example.${APPS_ROUTE_VERSION}\ncount_and_save"
-      },
-      "classes": "EVENT"
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.query_concurrently"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
-        "label": ""
-      }
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
+      "content": "POST"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.query_something",
-        "label": ""
-      }
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncollector.collect_spawn"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
-        "label": ""
-      }
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
+      "content": "POST"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.save_something",
-        "label": ""
-      }
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.spawn_event"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.download_something",
-        "label": ""
-      }
+    "classes": "EVENT"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
+      "content": "POST"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
-        "label": ""
-      }
+    "classes": "REQUEST"
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
+    "data": {
+      "id": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
+      "content": "simple_example.${APPS_ROUTE_VERSION}\nshuffle.parallelize_event"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
-        "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
-        "label": "high-prio"
-      }
+    "classes": "EVENT"
+  },
+  "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET": {
+    "data": {
+      "id": "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
+      "content": "GET"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
-        "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
-        "label": ""
-      }
+    "classes": "REQUEST"
+  },
+  "client_example.${APPS_ROUTE_VERSION}.count_and_save": {
+    "data": {
+      "id": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "content": "client_example.${APPS_ROUTE_VERSION}\ncount_and_save"
     },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
-        "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": "high-prio"
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
-        "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
-        "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
-        "label": ""
-      }
-    },
-    "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
-      "data": {
-        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
-        "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
-        "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-        "label": ""
-      }
-    },
-    "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.GET": {
-      "data": {
-        "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
-        "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
-        "target": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
-        "label": ""
-      }
-    },
-    "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.list_somethings.GET": {
-      "data": {
-        "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.list_somethings.GET",
-        "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
-        "label": ""
-      }
-    },
-    "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.save_something.POST": {
-      "data": {
-        "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.save_something.POST",
-        "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
-        "target": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
-        "label": ""
-      }
+    "classes": "EVENT"
+  },
+  "edge_basic_auth.${APPS_ROUTE_VERSION}.decode.GET": {
+    "data": {
+      "id": "edge_basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "source": "basic_auth.${APPS_ROUTE_VERSION}.decode.GET",
+      "target": "basic_auth.${APPS_ROUTE_VERSION}.decode",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.list_somethings",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.query_something",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.query_something_extended",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.save_something",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.download_something.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.download_something",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.upload_something.MULTIPART",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.upload_something",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+      "label": "high-prio"
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.process_events.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.service.something_generator.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.service.something_generator",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.streams.something_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.high-prio",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": "high-prio"
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.POST",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.simple_example.${APPS_ROUTE_VERSION}.streams.something_event.AUTO",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event",
+      "target": ">simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "label": ""
+    }
+  },
+  "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.GET": {
+    "data": {
+      "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
+      "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save.GET",
+      "target": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "label": ""
+    }
+  },
+  "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.login.GET": {
+    "data": {
+      "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.login.GET",
+      "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login.GET",
+      "label": ""
+    }
+  },
+  "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.list_somethings.GET": {
+    "data": {
+      "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.list_somethings.GET",
+      "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.list_somethings.GET",
+      "label": ""
+    }
+  },
+  "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.save_something.POST": {
+    "data": {
+      "id": "edge_client_example.${APPS_ROUTE_VERSION}.count_and_save.simple-example.save_something.POST",
+      "source": "client_example.${APPS_ROUTE_VERSION}.count_and_save",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.save_something.POST",
+      "label": ""
     }
   }
+}

--- a/plugins/ops/apps-visualizer/test/integration/test_events_graph.py
+++ b/plugins/ops/apps-visualizer/test/integration/test_events_graph.py
@@ -7,10 +7,10 @@ from . import mock_runtime
 
 @pytest.mark.asyncio
 async def test_simple_example_events_diagram(
-    monkeypatch, mock_lock, events_graph_data_standard, plugin_config
+    monkeypatch, mock_lock, events_graph_data_standard, plugin_config, effective_events
 ):
     async with mock_lock:
-        mock_runtime(monkeypatch)
+        mock_runtime(monkeypatch, effective_events)
         result = await execute_event(app_config=plugin_config, event_name="apps.events-graph", payload=None)
 
         assert result.graph.data == events_graph_data_standard
@@ -19,10 +19,10 @@ async def test_simple_example_events_diagram(
 
 @pytest.mark.asyncio
 async def test_simple_example_events_diagram_expanded_view(
-    monkeypatch, mock_lock, events_graph_data_expanded, plugin_config
+    monkeypatch, mock_lock, events_graph_data_expanded, plugin_config, effective_events
 ):
     async with mock_lock:
-        mock_runtime(monkeypatch)
+        mock_runtime(monkeypatch, effective_events)
         result = await execute_event(
             app_config=plugin_config, event_name="apps.events-graph", payload=None, expanded_view="true"
         )
@@ -33,10 +33,10 @@ async def test_simple_example_events_diagram_expanded_view(
 
 @pytest.mark.asyncio
 async def test_simple_example_events_diagram_filter_apps(
-    monkeypatch, mock_lock, events_graph_data_standard, plugin_config
+    monkeypatch, mock_lock, events_graph_data_standard, plugin_config, effective_events
 ):
     async with mock_lock:
-        mock_runtime(monkeypatch)
+        mock_runtime(monkeypatch, effective_events)
         filtered_events_graph_data = {
             k: v for k, v in events_graph_data_standard.items() if "simple_example" in k
         }

--- a/plugins/ops/apps-visualizer/test/integration/test_site.py
+++ b/plugins/ops/apps-visualizer/test/integration/test_site.py
@@ -6,9 +6,9 @@ from . import mock_runtime
 
 
 @pytest.mark.asyncio
-async def test_site_main(monkeypatch, mock_lock, plugin_config):
+async def test_site_main(monkeypatch, mock_lock, plugin_config, effective_events):
     async with mock_lock:
-        mock_runtime(monkeypatch)
+        mock_runtime(monkeypatch, effective_events)
 
         result, page, _ = await execute_event(
             app_config=plugin_config, event_name="site.main", payload=None, postprocess=True

--- a/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
@@ -4,18 +4,23 @@ Manage access to server runtime running applications
 import socket
 import os
 from typing import Dict
-from hopeit.app.config import AppConfig, EventDescriptor, EventPlugMode
+from hopeit.app.config import EventDescriptor, EventPlugMode
 
 from hopeit.server import runtime
 
 from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
 from hopeit.server.engine import AppEngine
 
-from hopeit.server.imports import find_event_handler
-from hopeit.server.steps import split_event_stages
-
 
 def _effective_events(app_engine: AppEngine, expand_events: bool) -> Dict[str, EventDescriptor]:
+    """
+    Build effective events reponse section, which contains unique keys to indentify events from
+    multiple apps.
+
+    - Prefixes each event_name in dictionary key with the app_key of the event
+    - If expand_events is True, gathers event list from app_engine effective_events instead of original config
+    - Handles events with plug_mode=ON_APP prepending the plugin app_key
+    """
     active_events = {}
     app_config = app_engine.app_config
     app_key = app_config.app_key()

--- a/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/runtime.py
@@ -9,31 +9,29 @@ from hopeit.app.config import AppConfig, EventDescriptor, EventPlugMode
 from hopeit.server import runtime
 
 from hopeit.config_manager import RuntimeAppInfo, RuntimeApps, ServerInfo, ServerStatus
+from hopeit.server.engine import AppEngine
 
 from hopeit.server.imports import find_event_handler
 from hopeit.server.steps import split_event_stages
 
 
-def _effective_events(app_config: AppConfig, expand_events: bool) -> Dict[str, EventDescriptor]:
+def _effective_events(app_engine: AppEngine, expand_events: bool) -> Dict[str, EventDescriptor]:
     active_events = {}
+    app_config = app_engine.app_config
+    app_key = app_config.app_key()
     for plugin_info in app_config.plugins:
-        plugin_config = runtime.server.app_engines[plugin_info.app_key()].app_config
-        for event_name, event_info in plugin_config.events.items():
+        plugin_engine = runtime.server.app_engines[plugin_info.app_key()]
+        plugin_config = plugin_engine.app_config
+        plugin_key = plugin_config.app_key()
+        events = plugin_engine.effective_events if expand_events else plugin_config.events
+        for event_name, event_info in events.items():
             if event_info.plug_mode == EventPlugMode.ON_APP:
-                active_events[event_name] = event_info
+                active_events[f"{app_key}.{plugin_key}.{event_name}"] = event_info
 
-    for event_name, event_info in app_config.events.items():
+    events = app_engine.effective_events if expand_events else app_config.events
+    for event_name, event_info in events.items():
         if event_info.plug_mode != EventPlugMode.ON_APP:
-            active_events[event_name] = event_info
-
-    if expand_events:
-        expanded_events = {}
-        for event_name, event_info in active_events.items():
-            impl = find_event_handler(app_config=app_config, event_name=event_name)
-            splits = split_event_stages(app_config.app, event_name, event_info, impl)
-            for name, info in splits.items():
-                expanded_events[name] = info
-        return expanded_events
+            active_events[f"{app_key}.{event_name}"] = event_info
 
     return active_events
 
@@ -48,7 +46,7 @@ def get_in_process_config(url: str, expand_events: bool):
                     url=url
                 )],
                 app_config=app_engine.app_config,
-                effective_events=_effective_events(app_engine.app_config, expand_events=expand_events)
+                effective_events=_effective_events(app_engine, expand_events=expand_events)
             )
             for app_key, app_engine in runtime.server.app_engines.items()
         },

--- a/plugins/ops/config-manager/test/integration/conftest.py
+++ b/plugins/ops/config-manager/test/integration/conftest.py
@@ -1,11 +1,12 @@
-import pytest
-
-from hopeit.dataobjects.payload import Payload
-from hopeit.config_manager import RuntimeApps, ServerStatus
 import socket
 import os
+import json
 
+import pytest
+from hopeit.app.config import EventDescriptor
 from hopeit.server.version import APPS_API_VERSION, ENGINE_VERSION, APPS_ROUTE_VERSION
+from hopeit.dataobjects.payload import Payload
+from hopeit.config_manager import RuntimeApps, ServerStatus
 
 
 RUNTIME_SIMPLE_EXAMPLE = """
@@ -40,6 +41,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           ],
           "cors_origin": "*"
         },
+        "app_connections": {},
         "env": {
           "fs": {
             "data_path": "/tmp/simple_example.${APPS_ROUTE_VERSION}.fs.data_path/"
@@ -53,6 +55,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "list_somethings": {
             "type": "GET",
             "plug_mode": "Standalone",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -79,6 +82,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "GET",
             "plug_mode": "Standalone",
             "route": "simple-example/${APPS_API_VERSION}/query_something",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -105,6 +109,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "type": "POST",
             "plug_mode": "Standalone",
             "route": "simple-example/${APPS_API_VERSION}/query_something",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -130,6 +135,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "save_something": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -155,6 +161,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "download_something": {
             "type": "GET",
             "plug_mode": "Standalone",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -180,6 +187,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "upload_something": {
             "type": "MULTIPART",
             "plug_mode": "Standalone",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -205,6 +213,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "service.something_generator": {
             "type": "SERVICE",
             "plug_mode": "Standalone",
+            "connections": [],
             "write_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
@@ -237,6 +246,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "streams.something_event": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "write_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
@@ -271,6 +281,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "streams.process_events": {
             "type": "STREAM",
             "plug_mode": "Standalone",
+            "connections": [],
             "read_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
@@ -310,6 +321,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "collector.query_concurrently": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "config": {
               "response_timeout": 60.0,
               "logging": {
@@ -335,6 +347,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "collector.collect_spawn": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "write_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
@@ -369,6 +382,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "shuffle.spawn_event": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "write_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
@@ -403,6 +417,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "shuffle.parallelize_event": {
             "type": "POST",
             "plug_mode": "Standalone",
+            "connections": [],
             "write_stream": {
               "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
               "queues": [
@@ -463,10 +478,95 @@ RUNTIME_SIMPLE_EXAMPLE = """
             "name": "basic-auth",
             "version": "${APPS_API_VERSION}"
           }
-        ]
+        ],
+        "settings": {}
       },
       "effective_events": {
-        "list_somethings": {
+        "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login": {
+          "type": "GET",
+          "plug_mode": "OnApp",
+          "connections": [],
+          "config": {
+            "response_timeout": 60.0,
+            "logging": {
+              "extra_fields": [],
+              "stream_fields": [
+                "stream.name",
+                "stream.msg_id",
+                "stream.consumer_group"
+              ]
+            },
+            "stream": {
+              "timeout": 60.0,
+              "target_max_len": 0,
+              "throttle_ms": 0,
+              "step_delay": 0,
+              "batch_size": 100,
+              "compression": "lz4",
+              "serialization": "json+base64"
+            }
+          },
+          "auth": [
+            "Basic"
+          ]
+        },
+        "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh": {
+          "type": "GET",
+          "plug_mode": "OnApp",
+          "connections": [],
+          "config": {
+            "response_timeout": 60.0,
+            "logging": {
+              "extra_fields": [],
+              "stream_fields": [
+                "stream.name",
+                "stream.msg_id",
+                "stream.consumer_group"
+              ]
+            },
+            "stream": {
+              "timeout": 60.0,
+              "target_max_len": 0,
+              "throttle_ms": 0,
+              "step_delay": 0,
+              "batch_size": 100,
+              "compression": "lz4",
+              "serialization": "json+base64"
+            }
+          },
+          "auth": [
+            "Refresh"
+          ]
+        },
+        "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout": {
+          "type": "GET",
+          "plug_mode": "OnApp",
+          "connections": [],
+          "config": {
+            "response_timeout": 60.0,
+            "logging": {
+              "extra_fields": [],
+              "stream_fields": [
+                "stream.name",
+                "stream.msg_id",
+                "stream.consumer_group"
+              ]
+            },
+            "stream": {
+              "timeout": 60.0,
+              "target_max_len": 0,
+              "throttle_ms": 0,
+              "step_delay": 0,
+              "batch_size": 100,
+              "compression": "lz4",
+              "serialization": "json+base64"
+            }
+          },
+          "auth": [
+            "Refresh"
+          ]
+        },
+        "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
           "type": "GET",
           "plug_mode": "Standalone",
           "connections": [],
@@ -492,7 +592,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "query_something": {
+        "simple_example.${APPS_ROUTE_VERSION}.query_something": {
           "type": "GET",
           "plug_mode": "Standalone",
           "route": "simple-example/${APPS_API_VERSION}/query_something",
@@ -519,7 +619,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "query_something_extended": {
+        "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
           "type": "POST",
           "plug_mode": "Standalone",
           "route": "simple-example/${APPS_API_VERSION}/query_something",
@@ -546,7 +646,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "save_something": {
+        "simple_example.${APPS_ROUTE_VERSION}.save_something": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
@@ -572,7 +672,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "download_something": {
+        "simple_example.${APPS_ROUTE_VERSION}.download_something": {
           "type": "GET",
           "plug_mode": "Standalone",
           "connections": [],
@@ -598,7 +698,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "upload_something": {
+        "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
           "type": "MULTIPART",
           "plug_mode": "Standalone",
           "connections": [],
@@ -624,7 +724,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "service.something_generator": {
+        "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
           "type": "SERVICE",
           "plug_mode": "Standalone",
           "connections": [],
@@ -657,7 +757,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "streams.something_event": {
+        "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
@@ -692,7 +792,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "streams.process_events": {
+        "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
           "type": "STREAM",
           "plug_mode": "Standalone",
           "connections": [],
@@ -732,7 +832,7 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "collector.query_concurrently": {
+        "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
@@ -758,52 +858,10 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "collector.collect_spawn": {
+        "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
-          "write_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
-            "queues": [
-              "AUTO"
-            ],
-            "queue_strategy": "PROPAGATE"
-          },
-          "config": {
-            "response_timeout": 60.0,
-            "logging": {
-              "extra_fields": [
-                "something_id"
-              ],
-              "stream_fields": [
-                "stream.name",
-                "stream.msg_id",
-                "stream.consumer_group"
-              ]
-            },
-            "stream": {
-              "timeout": 60.0,
-              "target_max_len": 1000,
-              "throttle_ms": 0,
-              "step_delay": 0,
-              "batch_size": 100,
-              "compression": "lz4",
-              "serialization": "json+base64"
-            }
-          },
-          "auth": []
-        },
-        "collector.collect_spawn$spawn": {
-          "type": "STREAM",
-          "plug_mode": "Standalone",
-          "connections": [],
-          "read_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.collector@load_first",
-            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.spawn",
-            "queues": [
-              "AUTO"
-            ]
-          },
           "write_stream": {
             "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
             "queues": [
@@ -835,52 +893,10 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "shuffle.spawn_event": {
+        "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
-          "write_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
-            "queues": [
-              "AUTO"
-            ],
-            "queue_strategy": "PROPAGATE"
-          },
-          "config": {
-            "response_timeout": 60.0,
-            "logging": {
-              "extra_fields": [
-                "something_id"
-              ],
-              "stream_fields": [
-                "stream.name",
-                "stream.msg_id",
-                "stream.consumer_group"
-              ]
-            },
-            "stream": {
-              "timeout": 60.0,
-              "target_max_len": 1000,
-              "throttle_ms": 0,
-              "step_delay": 0,
-              "batch_size": 100,
-              "compression": "lz4",
-              "serialization": "json+base64"
-            }
-          },
-          "auth": []
-        },
-        "shuffle.spawn_event$update_status": {
-          "type": "STREAM",
-          "plug_mode": "Standalone",
-          "connections": [],
-          "read_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.spawn_many_events",
-            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event.update_status",
-            "queues": [
-              "AUTO"
-            ]
-          },
           "write_stream": {
             "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
             "queues": [
@@ -912,94 +928,10 @@ RUNTIME_SIMPLE_EXAMPLE = """
           },
           "auth": []
         },
-        "shuffle.parallelize_event": {
+        "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
           "type": "POST",
           "plug_mode": "Standalone",
           "connections": [],
-          "write_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
-            "queues": [
-              "AUTO"
-            ],
-            "queue_strategy": "PROPAGATE"
-          },
-          "config": {
-            "response_timeout": 60.0,
-            "logging": {
-              "extra_fields": [
-                "something_id"
-              ],
-              "stream_fields": [
-                "stream.name",
-                "stream.msg_id",
-                "stream.consumer_group"
-              ]
-            },
-            "stream": {
-              "timeout": 60.0,
-              "target_max_len": 1000,
-              "throttle_ms": 0,
-              "step_delay": 0,
-              "batch_size": 100,
-              "compression": "lz4",
-              "serialization": "json+base64"
-            }
-          },
-          "auth": []
-        },
-        "shuffle.parallelize_event$process_first_part": {
-          "type": "STREAM",
-          "plug_mode": "Standalone",
-          "connections": [],
-          "read_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.fork_something",
-            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
-            "queues": [
-              "AUTO"
-            ]
-          },
-          "write_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
-            "queues": [
-              "AUTO"
-            ],
-            "queue_strategy": "PROPAGATE"
-          },
-          "config": {
-            "response_timeout": 60.0,
-            "logging": {
-              "extra_fields": [
-                "something_id"
-              ],
-              "stream_fields": [
-                "stream.name",
-                "stream.msg_id",
-                "stream.consumer_group"
-              ]
-            },
-            "stream": {
-              "timeout": 60.0,
-              "target_max_len": 1000,
-              "throttle_ms": 0,
-              "step_delay": 0,
-              "batch_size": 100,
-              "compression": "lz4",
-              "serialization": "json+base64"
-            }
-          },
-          "auth": []
-        },
-        "shuffle.parallelize_event$update_status": {
-          "type": "STREAM",
-          "plug_mode": "Standalone",
-          "connections": [],
-          "read_stream": {
-            "name": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.process_first_part",
-            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event.update_status",
-            "queues": [
-              "AUTO"
-            ]
-          },
           "write_stream": {
             "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
             "queues": [
@@ -1032,6 +964,212 @@ RUNTIME_SIMPLE_EXAMPLE = """
           "auth": []
         }
       }
+    },
+    "basic_auth.${APPS_ROUTE_VERSION}": {
+      "servers": [
+        {
+          "host_name": "${HOST_NAME}",
+          "pid": "${PID}",
+          "url": "${URL}"
+        }
+      ],
+      "app_config": {
+        "app": {
+          "name": "basic-auth",
+          "version": "${APPS_API_VERSION}"
+        },
+        "engine": {
+          "import_modules": [
+            "hopeit.basic_auth"
+          ],
+          "read_stream_timeout": 1000,
+          "read_stream_interval": 1000,
+          "default_stream_compression": "lz4",
+          "default_stream_serialization": "json+base64",
+          "track_headers": [
+            "track.request_id",
+            "track.request_ts"
+          ],
+          "cors_origin": "http://localhost:8020"
+        },
+        "app_connections": {},
+        "env": {
+          "auth": {
+            "access_token_expiration": 600,
+            "refresh_token_expiration": 3600,
+            "access_token_renew_window": 5
+          }
+        },
+        "events": {
+          "login": {
+            "type": "GET",
+            "plug_mode": "OnApp",
+            "connections": [],
+            "config": {
+              "response_timeout": 60.0,
+              "logging": {
+                "extra_fields": [],
+                "stream_fields": [
+                  "stream.name",
+                  "stream.msg_id",
+                  "stream.consumer_group"
+                ]
+              },
+              "stream": {
+                "timeout": 60.0,
+                "target_max_len": 0,
+                "throttle_ms": 0,
+                "step_delay": 0,
+                "batch_size": 100,
+                "compression": "lz4",
+                "serialization": "json+base64"
+              }
+            },
+            "auth": [
+              "Basic"
+            ]
+          },
+          "refresh": {
+            "type": "GET",
+            "plug_mode": "OnApp",
+            "connections": [],
+            "config": {
+              "response_timeout": 60.0,
+              "logging": {
+                "extra_fields": [],
+                "stream_fields": [
+                  "stream.name",
+                  "stream.msg_id",
+                  "stream.consumer_group"
+                ]
+              },
+              "stream": {
+                "timeout": 60.0,
+                "target_max_len": 0,
+                "throttle_ms": 0,
+                "step_delay": 0,
+                "batch_size": 100,
+                "compression": "lz4",
+                "serialization": "json+base64"
+              }
+            },
+            "auth": [
+              "Refresh"
+            ]
+          },
+          "logout": {
+            "type": "GET",
+            "plug_mode": "OnApp",
+            "connections": [],
+            "config": {
+              "response_timeout": 60.0,
+              "logging": {
+                "extra_fields": [],
+                "stream_fields": [
+                  "stream.name",
+                  "stream.msg_id",
+                  "stream.consumer_group"
+                ]
+              },
+              "stream": {
+                "timeout": 60.0,
+                "target_max_len": 0,
+                "throttle_ms": 0,
+                "step_delay": 0,
+                "batch_size": 100,
+                "compression": "lz4",
+                "serialization": "json+base64"
+              }
+            },
+            "auth": [
+              "Refresh"
+            ]
+          },
+          "decode": {
+            "type": "GET",
+            "plug_mode": "Standalone",
+            "connections": [],
+            "config": {
+              "response_timeout": 60.0,
+              "logging": {
+                "extra_fields": [],
+                "stream_fields": [
+                  "stream.name",
+                  "stream.msg_id",
+                  "stream.consumer_group"
+                ]
+              },
+              "stream": {
+                "timeout": 60.0,
+                "target_max_len": 0,
+                "throttle_ms": 0,
+                "step_delay": 0,
+                "batch_size": 100,
+                "compression": "lz4",
+                "serialization": "json+base64"
+              }
+            },
+            "auth": [
+              "Bearer"
+            ]
+          }
+        },
+        "server": {
+          "streams": {
+            "stream_manager": "hopeit.streams.NoStreamManager",
+            "connection_str": "<<NoStreamManager>>",
+            "delay_auto_start_seconds": 3
+          },
+          "logging": {
+            "log_level": "DEBUG",
+            "log_path": "logs/"
+          },
+          "auth": {
+            "secrets_location": ".secrets/",
+            "auth_passphrase": "",
+            "enabled": false,
+            "create_keys": false,
+            "encryption_algorithm": "RS256",
+            "default_auth_methods": [
+              "Unsecured"
+            ]
+          },
+          "api": {},
+          "engine_version": "${ENGINE_VERSION}"
+        },
+        "plugins": [],
+        "settings": {}
+      },
+      "effective_events": {
+        "basic_auth.${APPS_ROUTE_VERSION}.decode": {
+          "type": "GET",
+          "plug_mode": "Standalone",
+          "connections": [],
+          "config": {
+            "response_timeout": 60.0,
+            "logging": {
+              "extra_fields": [],
+              "stream_fields": [
+                "stream.name",
+                "stream.msg_id",
+                "stream.consumer_group"
+              ]
+            },
+            "stream": {
+              "timeout": 60.0,
+              "target_max_len": 0,
+              "throttle_ms": 0,
+              "step_delay": 0,
+              "batch_size": 100,
+              "compression": "lz4",
+              "serialization": "json+base64"
+            }
+          },
+          "auth": [
+            "Bearer"
+          ]
+        }
+      }
     }
   },
   "server_status": {
@@ -1040,9 +1178,77 @@ RUNTIME_SIMPLE_EXAMPLE = """
 }
 """
 
+EFFECTIVE_EVENTS_EXAMPLE = """
+{
+  "example_event$expanded": {
+    "type": "POST",
+    "plug_mode": "Standalone",
+    "connections": [],
+    "write_stream": {
+      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+      "queues": [
+        "AUTO"
+      ],
+      "queue_strategy": "DROP"
+    },
+    "config": {
+      "response_timeout": 60.0,
+      "logging": {
+        "extra_fields": [
+          "something_id"
+        ],
+        "stream_fields": [
+          "stream.name",
+          "stream.msg_id",
+          "stream.consumer_group"
+        ]
+      },
+      "stream": {
+        "timeout": 60.0,
+        "target_max_len": 1000,
+        "throttle_ms": 0,
+        "step_delay": 0,
+        "batch_size": 100,
+        "compression": "lz4",
+        "serialization": "json+base64"
+      }
+    },
+    "auth": []
+  },
+  "login$expanded": {
+    "type": "GET",
+    "plug_mode": "OnApp",
+    "connections": [],
+    "config": {
+      "response_timeout": 60.0,
+      "logging": {
+        "extra_fields": [],
+        "stream_fields": [
+          "stream.name",
+          "stream.msg_id",
+          "stream.consumer_group"
+        ]
+      },
+      "stream": {
+        "timeout": 60.0,
+        "target_max_len": 0,
+        "throttle_ms": 0,
+        "step_delay": 0,
+        "batch_size": 100,
+        "compression": "lz4",
+        "serialization": "json+base64"
+      }
+    },
+    "auth": [
+      "Basic"
+    ]
+  }
+}
+"""
 
-def _get_runtime_simple_example(url: str, expand_events: bool):
-    res = RUNTIME_SIMPLE_EXAMPLE
+
+def _get_runtime_simple_example(url: str, source: str):
+    res = source
     res = res.replace("${HOST_NAME}", socket.gethostname())
     res = res.replace("${PID}", str(os.getpid()))
     res = res.replace("${URL}", url)
@@ -1052,63 +1258,47 @@ def _get_runtime_simple_example(url: str, expand_events: bool):
 
     result = Payload.from_json(res, RuntimeApps)
 
-    if not expand_events:
-        for _, app_info in result.apps.items():
-            app_info.effective_events = app_info.app_config.events
-
     return result
 
 
 @pytest.fixture
 def runtime_apps_response():
-    return _get_runtime_simple_example("in-process", expand_events=False)
+    return _get_runtime_simple_example("in-process", source=RUNTIME_SIMPLE_EXAMPLE)
 
 
 @pytest.fixture
 def server1_apps_response():
-    return _get_runtime_simple_example("http://test-server1", expand_events=False)
+    return _get_runtime_simple_example("http://test-server1", source=RUNTIME_SIMPLE_EXAMPLE)
 
 
 @pytest.fixture
 def server2_apps_response():
-    return _get_runtime_simple_example("http://test-server2", expand_events=False)
+    return _get_runtime_simple_example("http://test-server2", source=RUNTIME_SIMPLE_EXAMPLE)
 
 
 @pytest.fixture
-def runtime_apps_response_exp():
-    return _get_runtime_simple_example("in-process", expand_events=True)
+def effective_events_example():
+    res = EFFECTIVE_EVENTS_EXAMPLE
+    res = res.replace("${ENGINE_VERSION}", ENGINE_VERSION)
+    res = res.replace("${APPS_API_VERSION}", APPS_API_VERSION)
+    res = res.replace("${APPS_ROUTE_VERSION}", APPS_ROUTE_VERSION)
+    res = json.loads(res)
 
+    result = Payload.from_obj(res, datatype=dict, item_datatype=EventDescriptor)
 
-@pytest.fixture
-def server1_apps_response_exp():
-    return _get_runtime_simple_example("http://test-server1", expand_events=True)
-
-
-@pytest.fixture
-def server2_apps_response_exp():
-    return _get_runtime_simple_example("http://test-server2", expand_events=True)
+    return result
 
 
 @pytest.fixture
 def cluster_apps_response():
-    server1 = _get_runtime_simple_example("http://test-server1", expand_events=False)
-    server2 = _get_runtime_simple_example("http://test-server2", expand_events=False)
+    server1 = _get_runtime_simple_example("http://test-server1", source=RUNTIME_SIMPLE_EXAMPLE)
+    server2 = _get_runtime_simple_example("http://test-server2", source=RUNTIME_SIMPLE_EXAMPLE)
 
     server1.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers.extend(
         server2.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers
     )
-    server1.server_status["http://test-server2"] = ServerStatus.ALIVE
-
-    return server1
-
-
-@pytest.fixture
-def cluster_apps_response_exp():
-    server1 = _get_runtime_simple_example("http://test-server1", expand_events=True)
-    server2 = _get_runtime_simple_example("http://test-server2", expand_events=True)
-
-    server1.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers.extend(
-        server2.apps[f"simple_example.{APPS_ROUTE_VERSION}"].servers
+    server1.apps[f"basic_auth.{APPS_ROUTE_VERSION}"].servers.extend(
+        server2.apps[f"basic_auth.{APPS_ROUTE_VERSION}"].servers
     )
     server1.server_status["http://test-server2"] = ServerStatus.ALIVE
 

--- a/plugins/ops/config-manager/test/integration/test_client.py
+++ b/plugins/ops/config-manager/test/integration/test_client.py
@@ -13,11 +13,6 @@ async def test_client(monkeypatch, cluster_apps_response,
 
     result = await client.get_apps_config("http://test-server1,http://test-server2", expand_events=False)
 
-    with open("file1.json", 'w') as f:
-        f.write(result.to_json(indent=2))
-    with open("file2.json", 'w') as f:
-        f.write(cluster_apps_response.to_json(indent=2))
-
     assert result == cluster_apps_response
 
 

--- a/plugins/ops/config-manager/test/integration/test_client.py
+++ b/plugins/ops/config-manager/test/integration/test_client.py
@@ -13,18 +13,26 @@ async def test_client(monkeypatch, cluster_apps_response,
 
     result = await client.get_apps_config("http://test-server1,http://test-server2", expand_events=False)
 
+    with open("file1.json", 'w') as f:
+        f.write(result.to_json(indent=2))
+    with open("file2.json", 'w') as f:
+        f.write(cluster_apps_response.to_json(indent=2))
+
     assert result == cluster_apps_response
 
 
 @pytest.mark.asyncio
-async def test_client_expand_events(monkeypatch, cluster_apps_response_exp,
-                                    server1_apps_response_exp, server2_apps_response_exp):
+async def test_client_expand_events(monkeypatch, effective_events_example,
+                                    server1_apps_response, server2_apps_response):
 
-    mock_client(client, monkeypatch, server1_apps_response_exp, server2_apps_response_exp, expand_events=True)
+    mock_client(
+        client, monkeypatch, server1_apps_response, server2_apps_response, effective_events_example
+    )
 
     result = await client.get_apps_config("http://test-server1,http://test-server2", expand_events=True)
 
-    assert result == cluster_apps_response_exp
+    for _, v in result.apps.items():
+        assert v.effective_events == effective_events_example
 
 
 @pytest.mark.asyncio

--- a/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
+++ b/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
@@ -23,15 +23,15 @@ async def test_cluster_apps_config(monkeypatch, cluster_apps_response,
 
 @pytest.mark.asyncio
 async def test_cluster_apps_config_expand_events(
-    monkeypatch, cluster_apps_response_exp,
-    server1_apps_response_exp, server2_apps_response_exp
+    monkeypatch, effective_events_example,
+    server1_apps_response, server2_apps_response
 ):
 
     def apply_mock_client(module, context):
         mock_client(
             module.client, monkeypatch,
-            server1_apps_response_exp, server2_apps_response_exp,
-            expand_events=True
+            server1_apps_response, server2_apps_response,
+            effective_events_example
         )
 
     plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
@@ -41,4 +41,5 @@ async def test_cluster_apps_config_expand_events(
         expand_events=True
     )
 
-    assert result == cluster_apps_response_exp
+    for _, v in result.apps.items():
+        assert v.effective_events == effective_events_example

--- a/plugins/ops/config-manager/test/integration/test_runtime_apps_config.py
+++ b/plugins/ops/config-manager/test/integration/test_runtime_apps_config.py
@@ -1,4 +1,5 @@
 import pytest
+from hopeit.app.config import EventPlugMode
 
 from hopeit.server import runtime
 from hopeit.testing.apps import config, execute_event
@@ -9,10 +10,11 @@ from . import MockServer
 @pytest.mark.asyncio
 async def test_runtime_apps_config(monkeypatch, runtime_apps_response):
     app_config = config('apps/examples/simple-example/config/app-config.json')
+    basic_auth_config = config('plugins/auth/basic-auth/config/plugin-config.json')
     monkeypatch.setattr(
         runtime,
         "server",
-        MockServer(app_config)
+        MockServer(app_config, basic_auth_config)
     )
 
     plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
@@ -22,13 +24,14 @@ async def test_runtime_apps_config(monkeypatch, runtime_apps_response):
 
 
 @pytest.mark.asyncio
-async def test_runtime_apps_config_expand_events(monkeypatch, runtime_apps_response_exp):
+async def test_runtime_apps_config_expand_events(monkeypatch, effective_events_example):
     app_config = config('apps/examples/simple-example/config/app-config.json')
-    monkeypatch.setattr(
-        runtime,
-        "server",
-        MockServer(app_config)
+    basic_auth_config = config('plugins/auth/basic-auth/config/plugin-config.json')
+    server = MockServer(app_config, basic_auth_config)
+    server.set_effective_events(
+        app_config.app_key(), effective_events_example
     )
+    monkeypatch.setattr(runtime, "server", server)
 
     plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
     result = await execute_event(
@@ -36,4 +39,11 @@ async def test_runtime_apps_config_expand_events(monkeypatch, runtime_apps_respo
         payload=None, expand_events=True
     )
 
-    assert result == runtime_apps_response_exp
+    app_prefix = app_config.app_key()
+    for k, v in result.apps[app_config.app_key()].effective_events.items():
+        assert k[0: len(app_prefix)] == app_prefix
+        if v.plug_mode == EventPlugMode.ON_APP:
+            app_plugin_prefx = f"{app_prefix}.{basic_auth_config.app_key()}"
+            assert k[0: len(app_plugin_prefx)] == app_plugin_prefx
+        event_name = k.split('.')[-1]
+        assert v == effective_events_example[event_name]

--- a/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
+++ b/plugins/ops/log-streamer/src/hopeit/log_streamer/__init__.py
@@ -83,7 +83,7 @@ class LogFileHandler(FileSystemEventHandler):
     It also keeps track of open files and ensures they are closed when inactive or deleted,
     allowing to work combined with `logrotate`.
     """
-    EVENTS_SORT_ORDER = ['START', '', 'DONE', 'FAILED']
+    EVENTS_SORT_ORDER = ['START', '', 'DONE', 'FAILED', 'IGNORED']
 
     def __init__(self, config: LogReaderConfig, context: EventContext):
         self.path = config.logs_path
@@ -122,7 +122,7 @@ class LogFileHandler(FileSystemEventHandler):
             logger.error(self.context, e)
 
     def _add_line(self, lines: List[str], line: str):
-        if ('| START |' in line) or ('| DONE |' in line) or ('| FAILED |' in line):
+        if ('| START |' in line) or ('| DONE |' in line) or ('| FAILED |' in line) or ('| IGNORED |') in line:
             lines.append(line)
 
     async def _on_event(self, event):

--- a/plugins/ops/log-streamer/src/hopeit/log_streamer/log_reader.py
+++ b/plugins/ops/log-streamer/src/hopeit/log_streamer/log_reader.py
@@ -63,7 +63,7 @@ async def _process_log_entry(entry: str, context: EventContext) -> Optional[LogE
     """
     Parses log line into a LogEntry
 
-    Only log entries with START/DONE/FAILED message are included.
+    Only log entries with START/DONE/FAILED/IGNORED message are included.
     (This behaviour can be changed if all lines should be processed)
     """
     try:
@@ -71,7 +71,7 @@ async def _process_log_entry(entry: str, context: EventContext) -> Optional[LogE
         if len(xs) >= 4:
             ts, app_info, msg, extras = xs[0], xs[2], xs[3], xs[4:]
             app_info_components = app_info.split(' ')
-            if msg in {'START', 'DONE', 'FAILED'} and (len(app_info_components) >= 3):
+            if msg in ('START', 'DONE', 'FAILED', 'IGNORED') and (len(app_info_components) >= 3):
                 app_name, app_version, event_name, host, pid = app_info_components[:5]
                 event = f"{auto_path(app_name, app_version)}.{event_name}"
                 extra_items = _parse_extras(extras)


### PR DESCRIPTION
AppsClient plugin:
- [x] Support to configure app_connections to call OnApp endpoints (endpoints provided by plugins running on top of apps)
- [x] Support different auth strategies:
  - [x] CLIENT_APP_PUBLIC_KEY( defauilt, current strategy, creates a Bearer token using Client App private key that can be decoded in server side with the public key)
  - [x] FORWARD_CONTEXT: creates an Authorization header using info in event context (can be used to propagate Basic auth)

AppsVisualizer plugin:
- [x] Fixes apps-visualizer for OnApp endpoints