### PR TITLE
fix(apps-client): Fix issue with getting client connections for events split with SHUFFLE

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Version 0.11.2
+______________
+- Fix: apps-client plugin, fixed issue where app_connections are not found when event is split with `SHUFFLE`
+
+
 Version 0.11.1
 ______________
 - Support for multiple steps with `Spawn` return values in a single step without needing to split using `SHUFFLE` steps.

--- a/engine/src/hopeit/app/events.py
+++ b/engine/src/hopeit/app/events.py
@@ -1,11 +1,11 @@
 """
 Events handling
 """
-from typing import AsyncGenerator, TypeVar, Type
+from typing import AsyncGenerator, Type, TypeVar
 
 from hopeit.dataobjects import EventPayloadType
-from hopeit.server.steps import CollectorStepsDescriptor, SHUFFLE
 from hopeit.server.collector import Collector
+from hopeit.server.steps import SHUFFLE, CollectorStepsDescriptor
 
 __all__ = ['Spawn', 'SHUFFLE', 'collector_step', 'Collector']
 

--- a/engine/src/hopeit/server/steps.py
+++ b/engine/src/hopeit/server/steps.py
@@ -309,6 +309,7 @@ def split_event_stages(app: AppDescriptor,
         sub_event_info = EventDescriptor(
             type=event_type,
             read_stream=read_stream,
+            connections=event_info.connections,
             write_stream=WriteStreamDescriptor(
                 name=intermediate_stream,
                 queue_strategy=StreamQueueStrategy.PROPAGATE

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.11.1"
+ENGINE_VERSION = "0.11.2"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/clients/apps-client/src/hopeit/apps_client/__init__.py
+++ b/plugins/clients/apps-client/src/hopeit/apps_client/__init__.py
@@ -310,7 +310,7 @@ class AppsClient(Client):
 
     def _get_event_connection(self, context: EventContext, event_name: str):
         try:
-            return self.event_connections[context.event_name][event_name]
+            return self.event_connections[context.event_name.split('$')[0]][event_name]
         except KeyError:
             raise AppConnectionNotFound(  # pylint: disable=raise-missing-from
                 f"Event {event_name} not found in event connections for {context.event_name}"


### PR DESCRIPTION
When events are split with SHUFFLE,
the second part of the event does not gain access to connections in settings,
so client calls fail.

This PR fixes this issue by sharing the same connections settings among pieces of split events.