### PR TITLE
fix(engine / apps-visualizer) Fix auth by event & apps visualizer

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -646,7 +646,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.14.1"
+            "default": "0.14.2"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -801,9 +801,5 @@
       }
     }
   },
-  "security": [
-    {
-      "auth.bearer": []
-    }
-  ]
+  "security": []
 }

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2020,7 +2020,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.14.1"
+            "default": "0.14.2"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -2284,9 +2284,5 @@
       }
     }
   },
-  "security": [
-    {
-      "auth.bearer": []
-    }
-  ]
+  "security": []
 }

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+Version 0.14.2
+______________
+- Fix: removed global security section from generate openapi file to allow per event configuration to take precedence
+
+Plugin: apps-visualizer
+  - Fix: pinned `cytoscape` version to latest stable
+
+
 Version 0.14.1
 ______________
 - Reworked web server startup:

--- a/engine/src/hopeit/server/api.py
+++ b/engine/src/hopeit/server/api.py
@@ -177,6 +177,7 @@ def register_apps(apps_config: List[AppConfig]):
                 plugin_config = apps_config_by_key[plugin.app_key()]
                 _register_api_spec(config, plugin_config)
         _cleanup_api_schemas()
+        _cleanup_global_auth()
 
 
 def _register_api_spec(app_config: AppConfig, plugin: Optional[AppConfig] = None):
@@ -480,6 +481,14 @@ def _cleanup_api_schemas():
                 clean[name] = schema
         modified = len(schemas) > len(clean)
         spec['components']['schemas'] = clean
+
+
+def _cleanup_global_auth():
+    """
+    Remove global security requirements as they are propagated path by path.
+    """
+    assert spec is not None
+    spec['security'] = []
 
 
 def _update_api_paths(app_config: AppConfig, plugin: Optional[AppConfig] = None):

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.14.1"
+ENGINE_VERSION = "0.14.2"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/test/mock_app/__init__.py
+++ b/engine/test/mock_app/__init__.py
@@ -786,10 +786,6 @@ def mock_api_spec():
             }
         },
         "security": [
-            {
-                "auth.bearer": []
-            }
-
         ]
     }
 

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -813,7 +813,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.14.1"
+            "default": "0.14.2"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -1009,9 +1009,5 @@
       }
     }
   },
-  "security": [
-    {
-      "auth.bearer": []
-    }
-  ]
+  "security": []
 }

--- a/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
+++ b/plugins/ops/apps-visualizer/src/hopeit/apps_visualizer/site/events_graph_template.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+    <script src="https://unpkg.com/cytoscape@3.9.4/dist/cytoscape.min.js"></script>
     <script src="https://unpkg.com/klayjs@0.4.1/klay.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/cytoscape-klay/cytoscape-klay.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/cytoscape-klay@3.1.4/cytoscape-klay.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css"


### PR DESCRIPTION
Context:
-Apps visualizaer was failing for 2 reasons
1) Unable to connect to config-manager endpoints markes as "Unsecured" due a a global requirement for Bearer auth
2) Latest cytoscape version (>3.9) failing to match nodes to select proper format.

This pr fixes:
___________
Engine:
   - [x] Fix: removed global security section from generate openapi file to allow per event configuration to take precedence

Plugin: apps-visualizer
  - [x] Fix: pinned `cytoscape` version to latest stable
