### PR TITLE
bug(cli): `hopeit_server` command line without `--enabled-groups` parameter or with an empty one prevents start the hopeit.engine 

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -660,7 +660,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.2"
+            "default": "0.16.3"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2052,7 +2052,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.2"
+            "default": "0.16.3"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Version 0.16.3
+______________
+Engine:
+- Fix: Calling the `hopeit_server` command line without `--enabled_groups` parameter or with an empty one prevents to
+start the server. Now `--enabled_groups` is an optional parameter.
+
 Version 0.16.2
 ______________
 Plugins:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -4,8 +4,8 @@ Release Notes
 Version 0.16.3
 ______________
 Engine:
-- Fix: Calling the `hopeit_server` command line without `--enabled_groups` parameter or with an empty one prevents to
-start the server. Now `--enabled_groups` is an optional parameter.
+- Fix: Calling the `hopeit_server` command line without `--enabled-groups` parameter or with an empty one prevents to
+start the server. Now `--enabled-groups` is an optional parameter.
 
 Version 0.16.2
 ______________

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -384,7 +384,7 @@
         },
         "engine_version": {
           "type": "string",
-          "default": "0.16.2"
+          "default": "0.16.3"
         }
       },
       "description": "\n    Server configuration\n    "

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -38,7 +38,7 @@
     },
     "engine_version": {
       "type": "string",
-      "default": "0.16.2"
+      "default": "0.16.3"
     }
   },
   "description": "\n    Server configuration\n    ",

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -19,17 +19,17 @@ def server():
 
 
 @server.command()
-@click.option('--config-files', prompt='Config files.',
+@click.option('--config-files', prompt='Config files',
               help='Comma-separated config file paths, starting with server config, then plugins, then apps.')
 @click.option('--api-file', help='Path to openapi complaint json specification.')
 @click.option('--host', default='0.0.0.0', help='Server host address or name.')
 @click.option('--port', default='8020', help='TCP/IP port to listen.')
 @click.option('--path', help='POSIX complaint socket name.')
 @click.option('--start-streams', is_flag=True, default=False, help='Auto start reading stream events.')
-@click.option('--enabled-groups', prompt='Comma-separated group labels.',
-              help="List of groups to start. If no group is specified, all events will be started."
-              "Events with DEFAULT or no group will always be started. DEAULT group label can be also"
-              "used explicitly to start only events with no group / default group.")
+@click.option('--enabled-groups', default='',
+              help="Optional comma-separated group labels to start. If no group is specified, all events will be"
+              " started. Events with no group or 'DEFAULT' group label will always be started. 'DEFAULT' group label"
+              " can also be used explicitly to start only events with no group or 'DEFAULT' group label.")
 def run(config_files: str, api_file: str, host: str, port: int, path: str, start_streams: bool, enabled_groups: str):
     """
     Runs web server hosting apps specified in config files.
@@ -37,7 +37,7 @@ def run(config_files: str, api_file: str, host: str, port: int, path: str, start
     web.prepare_engine(
         config_files=config_files.split(','),
         api_file=api_file,
-        enabled_groups=enabled_groups.split(','),
+        enabled_groups=enabled_groups.split(',') if enabled_groups else [],
         start_streams=start_streams,
     )
     web.serve(host=host, path=path, port=port)

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.16.2"
+ENGINE_VERSION = "0.16.3"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -827,7 +827,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.2"
+            "default": "0.16.3"
           }
         },
         "x-module-name": "hopeit.server.config",


### PR DESCRIPTION
Issue: 
------
Calling the `hopeit_server` command line without `--enabled-groups` parameter or with an empty one prevents start the server. 

Fix:
----
Set `--enabled-groups` as an optional parameter.