### PR TITLE
plugin(fs-storage): Added missing `events` package

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -754,7 +754,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.4"
+            "default": "0.16.5"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2052,7 +2052,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.4"
+            "default": "0.16.5"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Version 0.16.5
+______________
+Plugin: 
+  - fs-storage: include `hopeit.fs_storage.events` module in release package
+
+
 Version 0.16.4
 ______________
 Plugin: 

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.16.4"
+ENGINE_VERSION = "0.16.5"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -827,7 +827,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.16.4"
+            "default": "0.16.5"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/plugins/storage/fs/setup.py
+++ b/plugins/storage/fs/setup.py
@@ -40,11 +40,13 @@ setuptools.setup(
         "": "src"
     },
     packages=[
-        "hopeit.fs_storage"
+        "hopeit.fs_storage",
+        "hopeit.fs_storage.events",
     ],
     include_package_data=True,
     package_data={
         "hopeit.fs_storage": ["py.typed"]
+        "hopeit.fs_storage.events": ["py.typed"],
     },
     python_requires=">=3.7",
     install_requires=[

--- a/plugins/storage/fs/setup.py
+++ b/plugins/storage/fs/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
     ],
     include_package_data=True,
     package_data={
-        "hopeit.fs_storage": ["py.typed"]
+        "hopeit.fs_storage": ["py.typed"],
         "hopeit.fs_storage.events": ["py.typed"],
     },
     python_requires=">=3.7",


### PR DESCRIPTION
Version 0.16.5
______________
Plugin: 
  - fs-storage: include `hopeit.fs_storage.events` module in release package
