### PR TITLE
feature(engine): Enable OpenAPI on the fly, no api file is required

### DIFF
--- a/.github/workflows/hopeit-engine-qa.yml
+++ b/.github/workflows/hopeit-engine-qa.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.11","3.10", "3.9", "3.8"]
       max-parallel: 4
 
     steps:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
                 "--port=8020",
                 "--start-streams",
                 "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
-                "--api-auto=0.17;Simple Example;Simple Example OpenAPI specs"
+                "--api-auto=0.18;Simple Example;Simple Example OpenAPI specs"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,21 @@
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
-        },        
+        },
+        {
+            "name": "simple-example-auto",
+            "type": "python",
+            "request": "launch",
+            "module": "hopeit.server.web",
+            "args": [
+                "--port=8020",
+                "--start-streams",
+                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
+                "--api-auto=0.17;Simple Example;Simple Example OpenAPI specs"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
         {
             "name": "client-example",
             "type": "python",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![hopeit.engine QA](https://github.com/hopeit-git/hopeit.engine/workflows/hopeit.engine%20QA/badge.svg)
 
-> - Tested on Python 3.7, 3.8, 3.9 and 3.10
+> - Tested on Python 3.8, 3.9, 3.10 and 3.11
 > - Types and code style checks with [*mypy*](https://pypi.org/project/mypy/), [*flake*](https://pypi.org/project/flake8/) and [*pylint*](https://pypi.org/project/pylint/)
 > - *hopeit.engine* unit tested using [*pytest*](https://pypi.org/project/pytest/), required coverage > 90%
 > - HTTP server integration tests using [*pytest_aiohttp*](https://pypi.org/project/pytest-aiohttp/)

--- a/THIRDPARTY
+++ b/THIRDPARTY
@@ -1,7 +1,7 @@
 The following third-party libraries and services are needed to run hopeit.engine:
 
 
-python 3.7+:
+python 3.8+:
     Link: https://www.python.org/
     License: Python releases are Open Source. Historically, most, but not all, Python releases have also been GPL-compatible. The Licenses page details GPL-compatibility and Terms and Conditions. (https://docs.python.org/3/license.html)
 

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.17",
+    "version": "0.18",
     "title": "Client Example",
     "description": "Client Example"
   },
   "paths": {
-    "/api/config-manager/0x17/runtime-apps-config": {
+    "/api/config-manager/0x18/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
-    "/api/config-manager/0x17/cluster-apps-config": {
+    "/api/config-manager/0x18/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,11 +122,11 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
-    "/api/client-example/0x17/count-and-save": {
+    "/api/client-example/0x18/count-and-save": {
       "get": {
         "summary": "Client Example: Count Objects and Save new one",
         "description": "Count all available Something objects connecting to simple-example app",
@@ -193,7 +193,7 @@
           }
         },
         "tags": [
-          "client_example.0x17"
+          "client_example.0x18"
         ],
         "security": [
           {
@@ -202,7 +202,7 @@
         ]
       }
     },
-    "/api/client-example/0x17/handle-responses": {
+    "/api/client-example/0x18/handle-responses": {
       "get": {
         "summary": "Client Example: Handle Responses",
         "description": "Non default responses and UnhandledResponse exception\n\nTo manage different types of responses from the same endpoint we can use the `responses` parameter where we list the\nhttp response status codes expected and the corresponding data type for each one. In this example `app_call` expect\nand handle, 200 and 404 responses.\n\nAlso in the code you can see how to handle an expection of type `UnhandledResponse` and log as warining.",
@@ -287,7 +287,7 @@
           }
         },
         "tags": [
-          "client_example.0x17"
+          "client_example.0x18"
         ],
         "security": [
           {
@@ -757,7 +757,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.17.1"
+            "default": "0.18.0"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/client-example/setup.py
+++ b/apps/examples/client-example/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
         "client_example"
     ],
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web,cli,apps-client]=={version['ENGINE_VERSION']}",
         f"hopeit.basic-auth=={version['ENGINE_VERSION']}",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.17",
+    "version": "0.18",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/basic-auth/0x17/decode": {
+    "/api/basic-auth/0x18/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.0x17"
+          "basic_auth.0x18"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/config-manager/0x17/runtime-apps-config": {
+    "/api/config-manager/0x18/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -109,11 +109,11 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
-    "/api/config-manager/0x17/cluster-apps-config": {
+    "/api/config-manager/0x18/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -169,11 +169,11 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
-    "/api/simple-example/0x17/list-somethings": {
+    "/api/simple-example/0x18/list-somethings": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -243,7 +243,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -252,7 +252,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/query-something": {
+    "/api/simple-example/0x18/query-something": {
       "get": {
         "summary": "Simple Example: Query Something",
         "description": "Loads Something from disk",
@@ -338,7 +338,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -442,7 +442,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -451,7 +451,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/save-something": {
+    "/api/simple-example/0x18/save-something": {
       "post": {
         "summary": "Simple Example: Save Something",
         "description": "Creates and saves Something",
@@ -548,7 +548,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -557,7 +557,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/download-something": {
+    "/api/simple-example/0x18/download-something": {
       "get": {
         "summary": "Simple Example: Download Something",
         "description": "Download image file. The PostprocessHook return the requested file as stream.",
@@ -644,7 +644,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -653,7 +653,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/download-something-streamed": {
+    "/api/simple-example/0x18/download-something-streamed": {
       "get": {
         "summary": "Simple Example: Download Something Streamed",
         "description": "Download streamd created content as file.\nThe PostprocessHook return the requested resource as stream using `prepare_stream_response`.",
@@ -721,11 +721,11 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ]
       }
     },
-    "/api/simple-example/0x17/upload-something": {
+    "/api/simple-example/0x18/upload-something": {
       "post": {
         "summary": "Simple Example: Multipart Upload files",
         "description": "Upload files using Multipart form request",
@@ -863,7 +863,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -872,7 +872,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/streams/something-event": {
+    "/api/simple-example/0x18/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
         "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
@@ -941,7 +941,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -950,7 +950,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/collector/query-concurrently": {
+    "/api/simple-example/0x18/collector/query-concurrently": {
       "post": {
         "summary": "Simple Example: Query Concurrently",
         "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
@@ -1022,7 +1022,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -1031,7 +1031,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/collector/collect-spawn": {
+    "/api/simple-example/0x18/collector/collect-spawn": {
       "post": {
         "summary": "Simple Example: Collect and Spawn",
         "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
@@ -1109,7 +1109,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -1118,7 +1118,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/shuffle/spawn-event": {
+    "/api/simple-example/0x18/shuffle/spawn-event": {
       "post": {
         "summary": "Simple Example: Spawn Event",
         "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
@@ -1196,7 +1196,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -1205,7 +1205,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/shuffle/parallelize-event": {
+    "/api/simple-example/0x18/shuffle/parallelize-event": {
       "post": {
         "summary": "Simple Example: Parallelize Event",
         "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
@@ -1283,7 +1283,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -1292,7 +1292,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/basic-auth/0x17/login": {
+    "/api/simple-example/0x18/basic-auth/0x18/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -1360,7 +1360,7 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
@@ -1369,7 +1369,7 @@
         ]
       }
     },
-    "/api/simple-example/0x17/basic-auth/0x17/refresh": {
+    "/api/simple-example/0x18/basic-auth/0x18/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -1437,16 +1437,16 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
-            "simple_example.0x17.refresh": []
+            "simple_example.0x18.refresh": []
           }
         ]
       }
     },
-    "/api/simple-example/0x17/basic-auth/0x17/logout": {
+    "/api/simple-example/0x18/basic-auth/0x18/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -1523,11 +1523,11 @@
           }
         },
         "tags": [
-          "simple_example.0x17"
+          "simple_example.0x18"
         ],
         "security": [
           {
-            "simple_example.0x17.refresh": []
+            "simple_example.0x18.refresh": []
           }
         ]
       }
@@ -2055,7 +2055,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.17.1"
+            "default": "0.18.0"
           }
         },
         "x-module-name": "hopeit.server.config",
@@ -2316,10 +2316,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "simple_example.0x17.refresh": {
+      "simple_example.0x18.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "simple_example.0x17.refresh"
+        "name": "simple_example.0x18.refresh"
       }
     }
   },

--- a/apps/examples/simple-example/setup.py
+++ b/apps/examples/simple-example/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
         "common", "model", "simple_example"
     ],
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web,cli,redis-streams,fs-storage]=={version['ENGINE_VERSION']}",
         f"hopeit.fs-storage=={version['ENGINE_VERSION']}"

--- a/docs/source/quickstart/install.rst
+++ b/docs/source/quickstart/install.rst
@@ -6,7 +6,7 @@ API support and the Command Line interface tools to run a server and manage APIs
 
 hopeit.engine requires:
 
-* Python 3.7.x or above
+* Python 3.8.x or above
 
 1 - To install hopeit.engine with web server and command line interface support using pip on a virtual environment:
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,6 +12,8 @@ ______________
       to define API General Info.
       Default value is `None`.
 
+- Added test build for Python 3.11
+
 
 Version 0.17.1
 ______________

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,9 +1,22 @@
 Release Notes
 =============
 
+Version 0.18.0
+______________
+- Engine:
+
+  - `hopeit_server` command have new `--api-auto` param:
+    
+    - Setting: when `--api-file` is not defined, `--api-auto=version;title;description` allows to start `hopeit.engine`
+      with openapi enabled. You have to define `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs` 
+      to define API General Info.
+      Default value is `None`.
+
+
 Version 0.17.1
 ______________
 - Engine:
+
   - `hopeit_server` command have new `--workers-timeout` param: 
 
     - Setting `--workers-timeout=N`` a worker not responding for more than N seconds will be killed and restarted. 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,14 +5,14 @@ Version 0.18.0
 ______________
 - Engine:
 
-  - `hopeit_server` command have new `--api-auto` param:
+  - `hopeit_server` command now supports the `--api-auto` parameter:
     
-    - Setting: when `--api-file` is not defined, `--api-auto=version;title;description` allows to start `hopeit.engine`
-      with openapi enabled. You have to define `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs` 
-      to define API General Info.
-      Default value is `None`.
-
-- Added test build for Python 3.11
+    - Setting: When the `--api-file` is not specified, using `--api-auto=version;title;description`
+      enables the OpenAPI feature in hopeit.engine.
+      To define the API General Info, use `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs`.
+      The default value is `None`.
+    
+- Test build for Python 3.11 has been added.
 
 
 Version 0.17.1

--- a/engine/README.md
+++ b/engine/README.md
@@ -6,7 +6,7 @@ Docs: https://hopeitengine.readthedocs.io/en/latest/
 ### Engine development README
 
 #### Install locally for apps or plugins development:
-- Install Python 3.8, recommended (you can use 3.8 to 3.11)
+- Install Python 3.10, recommended (you can use 3.8 to 3.11)
 - Create and activate a virtual environment (recommended)
 - Run from hopeit.engine project root
 ```
@@ -17,7 +17,7 @@ Docs: https://hopeitengine.readthedocs.io/en/latest/
 
 #### Install from Python Package Index
 
-- Install Python 3.8, recommended (you can use 3.8 to 3.11)
+- Install Python 3.10, recommended (you can use 3.8 to 3.11)
 - Create and activate a virtual environment (recommended)
 - Install hopeit.engine
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -6,7 +6,7 @@ Docs: https://hopeitengine.readthedocs.io/en/latest/
 ### Engine development README
 
 #### Install locally for apps or plugins development:
-- Install Python 3.8, recommended (you can use 3.7 to 3.10)
+- Install Python 3.8, recommended (you can use 3.8 to 3.11)
 - Create and activate a virtual environment (recommended)
 - Run from hopeit.engine project root
 ```
@@ -17,7 +17,7 @@ Docs: https://hopeitengine.readthedocs.io/en/latest/
 
 #### Install from Python Package Index
 
-- Install Python 3.8, recommended (you can use 3.7 to 3.10)
+- Install Python 3.8, recommended (you can use 3.8 to 3.11)
 - Create and activate a virtual environment (recommended)
 - Install hopeit.engine
 

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -387,7 +387,7 @@
         },
         "engine_version": {
           "type": "string",
-          "default": "0.17.0"
+          "default": "0.18.0"
         }
       },
       "description": "\n    Server configuration\n    "

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -38,7 +38,7 @@
     },
     "engine_version": {
       "type": "string",
-      "default": "0.17.0"
+      "default": "0.18.0"
     }
   },
   "description": "\n    Server configuration\n    ",

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -54,10 +54,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -94,8 +94,8 @@ setuptools.setup(
         "hopeit.testing": ["py.typed"],
         "hopeit.toolkit": ["py.typed"]
     },
-    python_requires=">=3.7",
-    install_requires=[ f"{lib}>={libversion(lib)}" for lib in [
+    python_requires=">=3.8",
+    install_requires=[f"{lib}>={libversion(lib)}" for lib in [
         "lz4",
         "stringcase",
         "PyJWT[crypto]",

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -23,6 +23,8 @@ def server():
 @click.option('--config-files', required=True,
               help='Comma-separated config file paths, starting with server config, then plugins, then apps.')
 @click.option('--api-file', default=None, help='Path to openapi complaint json specification.')
+@click.option('--api-auto', default=None, help='When api_file is not defined, specify a comma-separated '
+              '`title,description` for automatic generated OpenAPI specs.')
 @click.option('--host', default='0.0.0.0', help='Server host address or name.')
 @click.option('--port', default=8020, help='TCP/IP port to listen.')
 @click.option('--path', help='POSIX complaint socket name.')
@@ -38,12 +40,13 @@ def server():
               "restarted. Value is a positive number or 0. Setting it to 0 has the effect of infinite timeouts "
               "by disabling timeouts for all workers entirely.")
 def run(config_files: str, api_file: str, host: str, port: int, path: str, start_streams: bool,
-        enabled_groups: str, workers: int, worker_class: str, worker_timeout: int):
+        enabled_groups: str, workers: int, worker_class: str, worker_timeout: int, api_auto: str):
     """
     Runs web server hosting apps specified in config files.
     """
     groups: List[str] = [] if enabled_groups == "" else enabled_groups.split(',')
     files: List[str] = config_files.split(',')
+    api_spec = [] if api_auto is None else api_auto.split(';')
 
     wsgi.run_app(
         host=host,
@@ -51,6 +54,7 @@ def run(config_files: str, api_file: str, host: str, port: int, path: str, start
         path=path,
         config_files=files,
         api_file=api_file,
+        api_auto=api_spec,
         start_streams=start_streams,
         enabled_groups=groups,
         workers=workers,

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -23,8 +23,9 @@ def server():
 @click.option('--config-files', required=True,
               help='Comma-separated config file paths, starting with server config, then plugins, then apps.')
 @click.option('--api-file', default=None, help='Path to openapi complaint json specification.')
-@click.option('--api-auto', default=None, help='When api_file is not defined, specify a comma-separated '
-              '`title,description` for automatic generated OpenAPI specs.')
+@click.option('--api-auto', default=None, help='When `api_file` is not defined, specify a semicolons-separated'
+              ' `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs` to define API General Info and'
+              ' enable the OpenAPI.')
 @click.option('--host', default='0.0.0.0', help='Server host address or name.')
 @click.option('--port', default=8020, help='TCP/IP port to listen.')
 @click.option('--path', help='POSIX complaint socket name.')

--- a/engine/src/hopeit/cli/server.py
+++ b/engine/src/hopeit/cli/server.py
@@ -24,7 +24,7 @@ def server():
               help='Comma-separated config file paths, starting with server config, then plugins, then apps.')
 @click.option('--api-file', default=None, help='Path to openapi complaint json specification.')
 @click.option('--api-auto', default=None, help='When `api_file` is not defined, specify a semicolons-separated'
-              ' `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs` to define API General Info and'
+              ' `--api-auto=0.18;Simple Example;Simple Example OpenAPI specs` to define API General Info and'
               ' enable the OpenAPI.')
 @click.option('--host', default='0.0.0.0', help='Server host address or name.')
 @click.option('--port', default=8020, help='TCP/IP port to listen.')

--- a/engine/src/hopeit/server/api.py
+++ b/engine/src/hopeit/server/api.py
@@ -114,22 +114,25 @@ def init_empty_spec(api_version: str, title: str, description: str):
     static_spec = deepcopy(spec)
 
 
+def init_auto_api(version: str, title: str, description: str):
+    global static_spec
+    logger.info(__name__, "On the fly api specs.")
+    init_empty_spec(version, title, description)
+    static_spec = None
+
+
 def load_api_file(path: Union[str, Path]):
     """
     Loads OpenAPI spec from a json file. Spec is loaded into the module.
     @param path: path to json file
     """
     global spec, static_spec
-    if path == 'AUTO':
-        logger.info(__name__, f"On the fly api specs when api_file={path}...")
-        init_empty_spec(OPEN_API_VERSION, "Auto generated OpenAPI", "OpenAPI definition")
-    else:
-        logger.info(__name__, f"Loading api spec from api_file={path}...")
-        with open(path, 'r', encoding="utf-8") as f:
-            spec = json.loads(f.read())
-            assert spec is not None
-            logger.info(__name__, f"API: openapi={spec['openapi']}, API version={spec['info']['version']}")
-            static_spec = deepcopy(spec)
+    logger.info(__name__, f"Loading api spec from api_file={path}...")
+    with open(path, 'r', encoding="utf-8") as f:
+        spec = json.loads(f.read())
+        assert spec is not None
+        logger.info(__name__, f"API: openapi={spec['openapi']}, API version={spec['info']['version']}")
+        static_spec = deepcopy(spec)
 
 
 def save_api_file(path: Union[str, Path], api_version: str):
@@ -157,14 +160,11 @@ def register_server_config(server_config: ServerConfig):
     """
     Register API definitions from server configuration. This consists of allowed and default authentication methods.
     """
-    global static_spec
     if spec is not None:
         if 'components' not in spec:
             spec['components'] = {'schemas': {}}
         _update_auth_methods()
         _update_server_default_auth_methods(server_config)
-        if server_config.api.api_file == 'AUTO':
-            static_spec = spec
 
 
 def register_apps(apps_config: List[AppConfig]):
@@ -287,7 +287,7 @@ def enable_swagger(server_config: ServerConfig, app: web.Application):
     if spec is None:
         logger.warning(__name__, "No api-file loaded. OpenAPI docs and validation disabled.")
         return
-    if server_config.api.api_file != "AUTO" and diff_specs():
+    if static_spec is not None and diff_specs():
         err = APIError("Cannot enable OpenAPI. Differences found between api-file and running apps. "
                        "Run `hopeit openapi diff` to check and `hopeit openapi update` to generate spec file")
         logger.error(__name__, err)

--- a/engine/src/hopeit/server/api.py
+++ b/engine/src/hopeit/server/api.py
@@ -54,6 +54,8 @@ _options = {
 
 OPEN_API_VERSION = '3.0.3'
 
+OPEN_API_DEFAULTS = ["hopeit.engine automatic OpenAPI title", "hopeit.engine automatic OpenAPI description"]
+
 METHOD_MAPPING = {
     EventType.GET: 'get',
     EventType.POST: 'post',

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -85,6 +85,7 @@ class APIConfig:
     Config for Open API docs page
     """
     docs_path: Optional[str] = None
+    api_file: Optional[str] = None
 
 
 @dataobject

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -85,7 +85,6 @@ class APIConfig:
     Config for Open API docs page
     """
     docs_path: Optional[str] = None
-    api_file: Optional[str] = None
 
 
 @dataobject

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.17.1"
+ENGINE_VERSION = "0.18.0"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -37,7 +37,7 @@ from hopeit.app.errors import BadRequest, Unauthorized
 from hopeit.dataobjects import DataObject, EventPayload, EventPayloadType
 from hopeit.dataobjects.payload import Payload
 from hopeit.server import api, runtime
-from hopeit.server.api import app_route_name
+from hopeit.server.api import app_route_name, OPEN_API_DEFAULTS
 from hopeit.server.config import (
     AuthType, ServerConfig, parse_server_config_json
 )
@@ -92,6 +92,10 @@ def prepare_engine(*, config_files: List[str], api_file: Optional[str], api_auto
         api.register_server_config(server_config)
 
     if api_file is None and api_auto:
+        if len(api_auto) < 3:
+            api_auto.extend(OPEN_API_DEFAULTS[len(api_auto) - 3:])
+        else:
+            api_auto = api_auto[:3]
         api.init_auto_api(api_auto[0], api_auto[1], api_auto[2])
         api.register_server_config(server_config)
 

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -758,7 +758,7 @@ def parse_args(args) -> ParsedArgs:
     --config-files, is a comma-separated list of hopeit apps config files relative or full paths
     --api-file, optional path to openapi.json file with at least openapi and info sections
     --api-auto, optional when api_file is not defined, specify a semicolons-separated 
-              `version;title;description` for automatic generated OpenAPI specs
+              `version;title;description` to define API General Info and enable OpenAPI
     --enabled-groups, optional list of group label to be started
     Example::
 

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -78,6 +78,7 @@ def prepare_engine(*, config_files: List[str], api_file: Optional[str], enabled_
     """
     logger.info("Loading engine config file=%s...", config_files[0])  # type: ignore
     server_config: ServerConfig = _load_engine_config(config_files[0])
+    server_config.api.api_file = api_file
 
     # Add startup hook to start engine
     web_server.on_startup.append(
@@ -85,8 +86,9 @@ def prepare_engine(*, config_files: List[str], api_file: Optional[str], enabled_
     )
     if server_config.auth.domain:
         auth_info_default['domain'] = server_config.auth.domain
-    if api_file is not None:
-        api.load_api_file(api_file)
+
+    if server_config.api.api_file is not None:
+        api.load_api_file(server_config.api.api_file)
         api.register_server_config(server_config)
 
     apps_config = []

--- a/engine/src/hopeit/server/wsgi.py
+++ b/engine/src/hopeit/server/wsgi.py
@@ -33,8 +33,8 @@ class WSGIApplication(gunicorn.app.base.BaseApplication):
         return self.application
 
 
-def run_app(host: str, port: int, path: Optional[str], config_files: List[str], api_file: str, start_streams: bool,
-            enabled_groups: List[str], workers: int, worker_class: str, worker_timeout: int):
+def run_app(host: str, port: int, path: Optional[str], config_files: List[str], api_file: str, api_auto: List[str],
+            start_streams: bool, enabled_groups: List[str], workers: int, worker_class: str, worker_timeout: int):
     """
     Gunicorn Web Runner
     """
@@ -55,6 +55,7 @@ def run_app(host: str, port: int, path: Optional[str], config_files: List[str], 
     app = init_web_server(
             config_files=config_files,
             api_file=api_file,
+            api_auto=api_auto,
             enabled_groups=enabled_groups,
             start_streams=start_streams)
 

--- a/engine/test/integration/cli/test_run.py
+++ b/engine/test/integration/cli/test_run.py
@@ -11,7 +11,7 @@ from hopeit.cli.server import run
 from hopeit.server import wsgi
 
 
-def run_app(host: str, port: int, path: Optional[str], config_files: List[str], api_file: str,
+def run_app(host: str, port: int, path: Optional[str], config_files: List[str], api_file: str, api_auto: List[str],
             start_streams: bool, enabled_groups: List[str], workers: int, worker_class: str, worker_timeout: int):
     print(f"Listening at: http://{host}:{port}")
 

--- a/engine/test/unit/server/test_web.py
+++ b/engine/test/unit/server/test_web.py
@@ -94,7 +94,11 @@ async def _stream_startup_hook(*args, **kwargs):
     )
 
 
-@pytest.mark.parametrize("api_file,api_auto", [('test_api_file.json', []), (None, ['0.18']), (None, None)])
+@pytest.mark.parametrize("api_file,api_auto", [
+    ('test_api_file.json', []),
+    (None, ['0.18', 'Title', 'Description']),
+    (None, ['0.18']),
+    (None, None)])
 @pytest.mark.asyncio
 async def test_server_initialization(monkeypatch, api_file, api_auto):
     async def _shutdown(*args, **kwargs):
@@ -115,16 +119,14 @@ async def test_server_initialization(monkeypatch, api_file, api_auto):
     nest_asyncio.apply()
 
     _load_engine_config = MagicMock()
-    if api_file:
-        _load_api_file = MagicMock()
+    _load_api_file = MagicMock()
     _enable_swagger = MagicMock()
     _register_server_config = MagicMock()
     _register_apps = MagicMock()
     _load_app_config = MagicMock()
 
     monkeypatch.setattr(web, '_load_engine_config', _load_engine_config)
-    if api_file:
-        monkeypatch.setattr(web.api, 'load_api_file', _load_api_file)
+    monkeypatch.setattr(web.api, 'load_api_file', _load_api_file)
     monkeypatch.setattr(web.api, 'register_server_config', _register_server_config)
     monkeypatch.setattr(web.api, 'register_apps', _register_apps)
     monkeypatch.setattr(web.api, 'enable_swagger', _enable_swagger)

--- a/engine/test/unit/server/test_web.py
+++ b/engine/test/unit/server/test_web.py
@@ -19,49 +19,49 @@ async def cleanup_test_server():
 def test_port_path():
     args = ['--port=8080', '--path=/tmp/test', '--config-files=engine.json,test.json']
     result = parse_args(args)
-    assert result == (None, 8080, '/tmp/test', False, ['engine.json', 'test.json'], None, [])
+    assert result == (None, 8080, '/tmp/test', False, ['engine.json', 'test.json'], None, [], [])
 
 
 def test_stream_start():
     args = ['--start-streams', '--config-files=test.json']
     result = parse_args(args)
-    assert result == (None, 8020, None, True, ['test.json'], None, [])
+    assert result == (None, 8020, None, True, ['test.json'], None, [], [])
 
 
 def test_port_only():
     args = ['--port=8020', '--config-files=test.json']
     result = parse_args(args)
-    assert result == (None, 8020, None, False, ['test.json'], None, [])
+    assert result == (None, 8020, None, False, ['test.json'], None, [], [])
 
 
 def test_path_only():
     args = ['--path=/tmp/test', '--config-files=test.json']
     result = parse_args(args)
-    assert result == (None, None, '/tmp/test', False, ['test.json'], None, [])
+    assert result == (None, None, '/tmp/test', False, ['test.json'], None, [], [])
 
 
 def test_rest_config_only():
     args = ['--config-files=test.json']
     result = parse_args(args)
-    assert result == (None, 8020, None, False, ['test.json'], None, [])
+    assert result == (None, 8020, None, False, ['test.json'], None, [], [])
 
 
 def test_rest_config_with_host():
     args = ['--host=127.0.0.1', '--config-files=test.json']
     result = parse_args(args)
-    assert result == ('127.0.0.1', 8020, None, False, ['test.json'], None, [])
+    assert result == ('127.0.0.1', 8020, None, False, ['test.json'], None, [], [])
 
 
 def test_config_with_api_file():
     args = ['--config-files=test.json', '--api-file=openapi.json']
     result = parse_args(args)
-    assert result == (None, 8020, None, False, ['test.json'], 'openapi.json', [])
+    assert result == (None, 8020, None, False, ['test.json'], 'openapi.json', [], [])
 
 
 def test_config_with_groups():
     args = ['--config-files=test.json', '--api-file=openapi.json', '--enabled-groups=g1,g2']
     result = parse_args(args)
-    assert result == (None, 8020, None, False, ['test.json'], 'openapi.json', ['g1', 'g2'])
+    assert result == (None, 8020, None, False, ['test.json'], 'openapi.json', [], ['g1', 'g2'])
 
 
 class MockHooks:
@@ -98,6 +98,7 @@ async def test_server_initialization(monkeypatch):
         web.init_web_server(
             config_files=['test_server_file.json', 'test_app_file.json', 'test_app_file2.json'],
             api_file='test_api_file.json',
+            api_auto=[],
             enabled_groups=[],
             start_streams=True
         )

--- a/engine/test/unit/server/test_web.py
+++ b/engine/test/unit/server/test_web.py
@@ -148,8 +148,7 @@ async def test_server_initialization(monkeypatch, api_file, api_auto):
         assert _load_engine_config.call_args[0] == ('test_server_file.json',)
         if api_file:
             assert _load_api_file.call_args[0] == ('test_api_file.json',)
-        if api_file or api_auto:
-            assert _register_server_config.call_count == 1
+        assert _register_server_config.call_count == (1 if api_file or api_auto else 0)
         assert _load_app_config.call_args_list[0][0] == ('test_app_file.json',)
         assert _load_app_config.call_args_list[1][0] == ('test_app_file2.json',)
         assert _register_apps.call_count == 1

--- a/plugins/auth/basic-auth/setup.py
+++ b/plugins/auth/basic-auth/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     package_data={
         "hopeit.basic_auth": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine=={version['ENGINE_VERSION']}",
         "PyJWT[crypto]>=2.4.0,<3"

--- a/plugins/clients/apps-client/setup.py
+++ b/plugins/clients/apps-client/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -46,7 +46,7 @@ setuptools.setup(
     package_data={
         "hopeit.apps_client": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web]=={version['ENGINE_VERSION']}"
     ],

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.17",
+    "version": "0.18",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/config-manager/0x17/runtime-apps-config": {
+    "/api/config-manager/0x18/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
-    "/api/config-manager/0x17/cluster-apps-config": {
+    "/api/config-manager/0x18/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,7 +122,7 @@
           }
         },
         "tags": [
-          "config_manager.0x17"
+          "config_manager.0x18"
         ]
       }
     },
@@ -209,11 +209,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x17"
+          "apps_visualizer.0x18"
         ]
       }
     },
-    "/api/apps-visualizer/0x17/apps/events-graph": {
+    "/api/apps-visualizer/0x18/apps/events-graph": {
       "get": {
         "summary": "App Visualizer: Events Graph Data",
         "description": "App Visualizer: Events Graph Data",
@@ -287,11 +287,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x17"
+          "apps_visualizer.0x18"
         ]
       }
     },
-    "/api/apps-visualizer/0x17/event-stats/live": {
+    "/api/apps-visualizer/0x18/event-stats/live": {
       "get": {
         "summary": "App Visualizer: Live Stats",
         "description": "App Visualizer: Live Stats",
@@ -365,7 +365,7 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x17"
+          "apps_visualizer.0x18"
         ]
       }
     }
@@ -830,7 +830,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.17.1"
+            "default": "0.18.0"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/plugins/ops/apps-visualizer/setup.py
+++ b/plugins/ops/apps-visualizer/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -54,7 +54,7 @@ setuptools.setup(
         "hopeit.apps_visualizer.site": ["*.html", "py.typed"]
     },
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web,log-streamer,config-manager]=={version['ENGINE_VERSION']}"
     ],

--- a/plugins/ops/config-manager/setup.py
+++ b/plugins/ops/config-manager/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -46,7 +46,7 @@ setuptools.setup(
     package_data={
         "hopeit.config_manager": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web]=={version['ENGINE_VERSION']}"
     ],

--- a/plugins/ops/log-streamer/setup.py
+++ b/plugins/ops/log-streamer/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -46,7 +46,7 @@ setuptools.setup(
     package_data={
         "hopeit.log_streamer": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine[web,fs-storage]=={version['ENGINE_VERSION']}",
         "watchdog"

--- a/plugins/storage/fs/setup.py
+++ b/plugins/storage/fs/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -48,7 +48,7 @@ setuptools.setup(
         "hopeit.fs_storage": ["py.typed"],
         "hopeit.fs_storage.events": ["py.typed"],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine=={version['ENGINE_VERSION']}",
         "aiofiles"

--- a/plugins/storage/redis/setup.py
+++ b/plugins/storage/redis/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -46,7 +46,7 @@ setuptools.setup(
     package_data={
         "hopeit.redis_storage": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine=={version['ENGINE_VERSION']}",
         "redis>=4.4.0,<5"

--- a/plugins/streams/redis/setup.py
+++ b/plugins/streams/redis/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
@@ -46,7 +46,7 @@ setuptools.setup(
     package_data={
         "hopeit.redis_streams": ["py.typed"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         f"hopeit.engine=={version['ENGINE_VERSION']}",
         "redis>=4.4.0,<5"


### PR DESCRIPTION
**FEATURE**

  - `hopeit_server` command has a new parameter `--api-auto`:
    - Setting: when `--api-file` is not defined, `--api-auto=version;title;description` (only version is mandatory) allows to start `hopeit.engine`
      with openapi enabled. You have to define `--api-auto=0.17;Simple Example;Simple Example OpenAPI specs` 
      to define API General Info.
      Default value is `None`.