### PR TITLE
fix(apps-visualizer): missing client timeout on request to config-manager

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -757,7 +757,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.19.0"
+            "default": "0.19.1"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2055,7 +2055,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.19.0"
+            "default": "0.19.1"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+Version 0.19.1
+______________
+- Plugins:
+
+  - config_manager: add `client_timeout` setting to `config_manager`` to prevent the server from waiting indefinitely for a response.
+  - apps-visualizer: using `config_manager` `client_timeout` setting preventing UI from blocking.
+
+
 Version 0.19.0
 ______________
 - Engine:

--- a/engine/src/hopeit/app/config.py
+++ b/engine/src/hopeit/app/config.py
@@ -460,7 +460,9 @@ class AppConfig:
             if event_name in self.settings:
                 extras['_'] = self.settings[event_name]
             for key in event_info.setting_keys:
-                extras[key] = self.settings[key]
+                value = self.settings.get(key)
+                if value is not None:
+                    extras[key] = value
             self.effective_settings[event_name]['extras'] = extras
 
 

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.19.0"
+ENGINE_VERSION = "0.19.1"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -830,7 +830,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.19.0"
+            "default": "0.19.1"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/plugins/ops/apps-visualizer/config/plugin-config.json
+++ b/plugins/ops/apps-visualizer/config/plugin-config.json
@@ -13,6 +13,9 @@
             "refresh_hosts_seconds": 60,
             "live_recent_treshold_seconds": 10,
             "live_active_treshold_seconds": 60
+        },
+        "config_manager": {
+            "client_timeout" : 10
         }
     },
     "events": {
@@ -20,12 +23,12 @@
             "type": "GET",
             "auth": ["Unsecured"],
             "route": "/ops/apps-visualizer",
-            "setting_keys": ["apps_visualizer"]
+            "setting_keys": ["apps_visualizer", "config_manager"]
         },
         "apps.events-graph": {
             "type": "GET",
             "auth": ["Unsecured"],
-            "setting_keys": ["apps_visualizer"]
+            "setting_keys": ["apps_visualizer", "config_manager"]
         },
         "event-stats.collect": {
             "type": "STREAM",
@@ -37,7 +40,7 @@
         "event-stats.live": {
             "type": "GET",
             "auth": ["Unsecured"],
-            "setting_keys": ["apps_visualizer"]
+            "setting_keys": ["apps_visualizer", "config_manager"]
         }
     }
 }

--- a/plugins/ops/apps-visualizer/config/plugin-config.json
+++ b/plugins/ops/apps-visualizer/config/plugin-config.json
@@ -3,8 +3,10 @@
         "name": "apps-visualizer",
         "version": "${HOPEIT_APPS_API_VERSION}"
     },
-    "engine" : {
-        "import_modules": ["hopeit.apps_visualizer"],
+    "engine": {
+        "import_modules": [
+            "hopeit.apps_visualizer"
+        ],
         "cors_origin": "http://localhost:8020"
     },
     "settings": {
@@ -14,21 +16,31 @@
             "live_recent_treshold_seconds": 10,
             "live_active_treshold_seconds": 60
         },
-        "config_manager": {
-            "client_timeout" : 10
+        "config_manager_client": {
+            "client_timeout": 11
         }
     },
     "events": {
         "site.main": {
             "type": "GET",
-            "auth": ["Unsecured"],
+            "auth": [
+                "Unsecured"
+            ],
             "route": "/ops/apps-visualizer",
-            "setting_keys": ["apps_visualizer", "config_manager"]
+            "setting_keys": [
+                "apps_visualizer",
+                "config_manager_client"
+            ]
         },
         "apps.events-graph": {
             "type": "GET",
-            "auth": ["Unsecured"],
-            "setting_keys": ["apps_visualizer", "config_manager"]
+            "auth": [
+                "Unsecured"
+            ],
+            "setting_keys": [
+                "apps_visualizer",
+                "config_manager_client"
+            ]
         },
         "event-stats.collect": {
             "type": "STREAM",
@@ -39,8 +51,13 @@
         },
         "event-stats.live": {
             "type": "GET",
-            "auth": ["Unsecured"],
-            "setting_keys": ["apps_visualizer", "config_manager"]
+            "auth": [
+                "Unsecured"
+            ],
+            "setting_keys": [
+                "apps_visualizer",
+                "config_manager_client"
+            ]
         }
     }
 }

--- a/plugins/ops/config-manager/config/plugin-config.json
+++ b/plugins/ops/config-manager/config/plugin-config.json
@@ -9,16 +9,16 @@
     ]
   },
   "settings": {
-    "config_manager": {
-      "client_timeout" : 10
-  }
+    "config_manager_client": {
+      "client_timeout": 10
+    }
   },
   "events": {
     "runtime_apps_config": {
       "type": "GET",
       "plug_mode": "Standalone",
       "setting_keys": [
-        "config_manager"
+        "config_manager_client"
       ],
       "auth": [
         "Unsecured"
@@ -28,7 +28,7 @@
       "type": "GET",
       "plug_mode": "Standalone",
       "setting_keys": [
-        "config_manager"
+        "config_manager_client"
       ],
       "auth": [
         "Unsecured"

--- a/plugins/ops/config-manager/config/plugin-config.json
+++ b/plugins/ops/config-manager/config/plugin-config.json
@@ -9,16 +9,16 @@
     ]
   },
   "settings": {
-    "client": {
-      "timeout": 10
-    }
+    "config_manager": {
+      "client_timeout" : 10
+  }
   },
   "events": {
     "runtime_apps_config": {
       "type": "GET",
       "plug_mode": "Standalone",
       "setting_keys": [
-        "client"
+        "config_manager"
       ],
       "auth": [
         "Unsecured"
@@ -28,7 +28,7 @@
       "type": "GET",
       "plug_mode": "Standalone",
       "setting_keys": [
-        "client"
+        "config_manager"
       ],
       "auth": [
         "Unsecured"

--- a/plugins/ops/config-manager/config/plugin-config.json
+++ b/plugins/ops/config-manager/config/plugin-config.json
@@ -1,22 +1,38 @@
 {
-    "app" : {
-      "name": "config-manager",
-      "version": "${HOPEIT_APPS_API_VERSION}"
+  "app": {
+    "name": "config-manager",
+    "version": "${HOPEIT_APPS_API_VERSION}"
+  },
+  "engine": {
+    "import_modules": [
+      "hopeit.config_manager"
+    ]
+  },
+  "settings": {
+    "client": {
+      "timeout": 10
+    }
+  },
+  "events": {
+    "runtime_apps_config": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "setting_keys": [
+        "client"
+      ],
+      "auth": [
+        "Unsecured"
+      ]
     },
-    "engine": {
-      "import_modules": ["hopeit.config_manager"]
-    },
-    "events": {
-      "runtime_apps_config" : {
-        "type": "GET",
-        "plug_mode": "Standalone",
-        "auth": ["Unsecured"]
-      },
-      "cluster_apps_config" : {
-        "type": "GET",
-        "plug_mode": "Standalone",
-        "auth": ["Unsecured"]
-      }
+    "cluster_apps_config": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "setting_keys": [
+        "client"
+      ],
+      "auth": [
+        "Unsecured"
+      ]
     }
   }
-  
+}

--- a/plugins/ops/config-manager/src/hopeit/config_manager/client.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/client.py
@@ -20,8 +20,8 @@ logger, extra = engine_extra_logger()
 
 @dataobject
 @dataclass
-class ConfigManagerSettings:
-    client_timeout: float
+class ConfigManagerClientSettings:
+    client_timeout: float = 10.0
 
 
 async def get_apps_config(hosts: str, context: EventContext, **kwargs) -> RuntimeApps:
@@ -60,11 +60,8 @@ async def _get_host_config(
     Invokes config-manager runtime-apps-config endpoint in a given host
     """
 
-    print("")
-    settings: ConfigManagerSettings = (
-        context.settings(key="config_manager", datatype=ConfigManagerSettings)
-        if hasattr(context.settings.extras, "config_manager")
-        else ConfigManagerSettings(client_timeout=60.0)
+    settings: ConfigManagerClientSettings = context.settings(
+        key="config_manager_client", datatype=ConfigManagerClientSettings
     )
 
     if host == "in-process":

--- a/plugins/ops/config-manager/src/hopeit/config_manager/client.py
+++ b/plugins/ops/config-manager/src/hopeit/config_manager/client.py
@@ -21,6 +21,12 @@ logger, extra = engine_extra_logger()
 @dataobject
 @dataclass
 class ConfigManagerClientSettings:
+    """
+    File storage plugin config
+
+
+    :field: client_timeout, float: client timeout in seconds, defults to 10.0
+    """
     client_timeout: float = 10.0
 
 

--- a/plugins/ops/config-manager/test/integration/__init__.py
+++ b/plugins/ops/config-manager/test/integration/__init__.py
@@ -112,7 +112,7 @@ def mock_context(event_name: str, timeout: Optional[float] = None) -> EventConte
     plugin_config = config("plugins/ops/config-manager/config/plugin-config.json")
     event_settings = get_event_settings(plugin_config.effective_settings, "cluster_apps_config")  # type: ignore
     if timeout:
-        event_settings.extras["client"]["timeout"] = timeout
+        event_settings.extras["config_manager_client"]["client_timeout"] = timeout
     return EventContext(
         app_config=app_config(),
         event_name=event_name,

--- a/plugins/ops/config-manager/test/integration/__init__.py
+++ b/plugins/ops/config-manager/test/integration/__init__.py
@@ -1,10 +1,14 @@
-from typing import Dict
+from typing import Dict, Optional
+
+import aiohttp
 
 from hopeit.app.config import AppConfig, EventDescriptor
-
 from hopeit.config_manager import RuntimeApps
-
 from hopeit.server.version import APPS_ROUTE_VERSION
+from hopeit.app.context import EventContext
+from hopeit.server.events import get_event_settings
+from hopeit.server.config import AuthType
+from hopeit.testing.apps import config
 
 
 class MockAppEngine:
@@ -15,16 +19,15 @@ class MockAppEngine:
 
 class MockServer:
     def __init__(self, *app_config: AppConfig):
-        self.app_engines = {
-            cfg.app_key(): MockAppEngine(cfg)
-            for cfg in app_config
-        }
+        self.app_engines = {cfg.app_key(): MockAppEngine(cfg) for cfg in app_config}
 
-    def set_effective_events(self, app_key: str, effective_events: Dict[str, EventDescriptor]):
+    def set_effective_events(
+        self, app_key: str, effective_events: Dict[str, EventDescriptor]
+    ):
         self.app_engines[app_key].effective_events = effective_events
 
 
-class MockResponse():
+class MockResponse:
     def __init__(self, response: RuntimeApps):
         self.response = response
 
@@ -38,17 +41,17 @@ class MockResponse():
         return self.response.to_dict()
 
 
-class MockClientSession():
-
+class MockClientSession:
     responses: Dict[str, RuntimeApps] = {}
+    timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=10.0)
 
     @classmethod
     def setup(cls, responses: Dict[str, RuntimeApps]):
         cls.responses = responses
         return cls
 
-    def __init__(self):
-        pass
+    def __init__(self, timeout: aiohttp.ClientTimeout):
+        self.timeout = timeout
 
     async def __aenter__(self):
         return self
@@ -57,6 +60,8 @@ class MockClientSession():
         return None
 
     def get(self, url: str) -> MockResponse:
+        if self.timeout.total is not None and self.timeout.total < 10.0:
+            raise TimeoutError()
         if url in self.responses:
             return MockResponse(self.responses[url])
         raise IOError("Test error")
@@ -69,18 +74,54 @@ def mock_effective_events(response, effective_events=None):
     return response
 
 
-def mock_client(module, monkeypatch, server1_apps_response, server2_apps_response, effective_events=None):
+def mock_client(
+    module,
+    monkeypatch,
+    server1_apps_response,
+    server2_apps_response,
+    effective_events=None,
+    timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=10.0),
+):
     expand_events = str(effective_events is not None).lower()
     url_pattern = "{}/api/config-manager/{}/runtime-apps-config?url={}&expand_events={}"
     url1 = url_pattern.format(
-        "http://test-server1", APPS_ROUTE_VERSION, "http://test-server1", str(expand_events).lower()
+        "http://test-server1",
+        APPS_ROUTE_VERSION,
+        "http://test-server1",
+        str(expand_events).lower(),
     )
     url2 = url_pattern.format(
-        "http://test-server2", APPS_ROUTE_VERSION, "http://test-server2", str(expand_events).lower()
+        "http://test-server2",
+        APPS_ROUTE_VERSION,
+        "http://test-server2",
+        str(expand_events).lower(),
     )
-    monkeypatch.setattr(module.aiohttp, 'ClientSession', MockClientSession.setup(
-        responses={
-            url1: mock_effective_events(server1_apps_response, effective_events),
-            url2: mock_effective_events(server2_apps_response, effective_events)
-        }
-    ))
+    monkeypatch.setattr(
+        module.aiohttp,
+        "ClientSession",
+        MockClientSession(timeout=timeout).setup(
+            responses={
+                url1: mock_effective_events(server1_apps_response, effective_events),
+                url2: mock_effective_events(server2_apps_response, effective_events),
+            }
+        ),
+    )
+
+
+def mock_context(event_name: str, timeout: Optional[float] = None) -> EventContext:
+    plugin_config = config("plugins/ops/config-manager/config/plugin-config.json")
+    event_settings = get_event_settings(plugin_config.effective_settings, "cluster_apps_config")  # type: ignore
+    if timeout:
+        event_settings.extras["client"]["timeout"] = timeout
+    return EventContext(
+        app_config=app_config(),
+        event_name=event_name,
+        plugin_config=plugin_config,
+        settings=event_settings,
+        track_ids={},
+        auth_info={"auth_type": AuthType.UNSECURED, "allowed": "true"},
+    )
+
+
+def app_config() -> AppConfig:
+    return config("plugins/ops/config-manager/config/plugin-config.json")

--- a/plugins/ops/config-manager/test/integration/__init__.py
+++ b/plugins/ops/config-manager/test/integration/__init__.py
@@ -43,7 +43,7 @@ class MockResponse:
 
 class MockClientSession:
     responses: Dict[str, RuntimeApps] = {}
-    timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=10.0)
+    # timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=10.0)
 
     @classmethod
     def setup(cls, responses: Dict[str, RuntimeApps]):
@@ -79,8 +79,7 @@ def mock_client(
     monkeypatch,
     server1_apps_response,
     server2_apps_response,
-    effective_events=None,
-    timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=10.0),
+    effective_events=None
 ):
     expand_events = str(effective_events is not None).lower()
     url_pattern = "{}/api/config-manager/{}/runtime-apps-config?url={}&expand_events={}"
@@ -99,7 +98,7 @@ def mock_client(
     monkeypatch.setattr(
         module.aiohttp,
         "ClientSession",
-        MockClientSession(timeout=timeout).setup(
+        MockClientSession.setup(
             responses={
                 url1: mock_effective_events(server1_apps_response, effective_events),
                 url2: mock_effective_events(server2_apps_response, effective_events),
@@ -110,9 +109,9 @@ def mock_client(
 
 def mock_context(event_name: str, timeout: Optional[float] = None) -> EventContext:
     plugin_config = config("plugins/ops/config-manager/config/plugin-config.json")
-    event_settings = get_event_settings(plugin_config.effective_settings, "cluster_apps_config")  # type: ignore
     if timeout:
-        event_settings.extras["config_manager_client"]["client_timeout"] = timeout
+        plugin_config.settings["config_manager_client"]["client_timeout"] = timeout
+    event_settings = get_event_settings(plugin_config.effective_settings, event_name)  # type: ignore
     return EventContext(
         app_config=app_config(),
         event_name=event_name,

--- a/plugins/ops/config-manager/test/integration/test_client.py
+++ b/plugins/ops/config-manager/test/integration/test_client.py
@@ -2,43 +2,77 @@ import pytest
 
 from hopeit.config_manager import ServerStatus, client
 
-from . import mock_client
+from . import mock_client, mock_context, app_config
+import hopeit.server.logger as server_logging
 
 
 @pytest.mark.asyncio
-async def test_client(monkeypatch, cluster_apps_response,
-                      server1_apps_response, server2_apps_response):
+async def test_client(
+    monkeypatch, cluster_apps_response, server1_apps_response, server2_apps_response
+):
+    _init_engine_logger(app_config())
+    context = mock_context(event_name="cluster_apps_config")
 
     mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
 
-    result = await client.get_apps_config("http://test-server1,http://test-server2", expand_events=False)
+    result = await client.get_apps_config(
+        "http://test-server1,http://test-server2", context, expand_events=False
+    )
 
     assert result == cluster_apps_response
 
 
 @pytest.mark.asyncio
-async def test_client_expand_events(monkeypatch, effective_events_example,
-                                    server1_apps_response, server2_apps_response):
+async def test_client_timeout(
+    monkeypatch, cluster_apps_response, server1_apps_response, server2_apps_response
+):
+    _init_engine_logger(app_config())
 
-    mock_client(
-        client, monkeypatch, server1_apps_response, server2_apps_response, effective_events_example
+    mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
+    context = mock_context(event_name="cluster_apps_config", timeout=5.0)
+
+    result = await client.get_apps_config(
+        "http://test-server1,http://test-server2", context, expand_events=False
     )
+    assert result.apps == {}
+    assert result.server_status == {
+        "http://test-server1": ServerStatus.ERROR,
+        "http://test-server2": ServerStatus.ERROR,
+    }
 
-    result = await client.get_apps_config("http://test-server1,http://test-server2", expand_events=True)
+
+@pytest.mark.asyncio
+async def test_client_expand_events(
+    monkeypatch, effective_events_example, server1_apps_response, server2_apps_response
+):
+    _init_engine_logger(app_config())
+    mock_client(
+        client,
+        monkeypatch,
+        server1_apps_response,
+        server2_apps_response,
+        effective_events_example,
+    )
+    context = mock_context(event_name="cluster_apps_config")
+    result = await client.get_apps_config(
+        "http://test-server1,http://test-server2", context, expand_events=True
+    )
 
     for _, v in result.apps.items():
         assert v.effective_events == effective_events_example
 
 
 @pytest.mark.asyncio
-async def test_client_ignore_hosts_errors(monkeypatch, cluster_apps_response,
-                                          server1_apps_response, server2_apps_response):
-
+async def test_client_ignore_hosts_errors(
+    monkeypatch, cluster_apps_response, server1_apps_response, server2_apps_response
+):
+    _init_engine_logger(app_config())
     mock_client(client, monkeypatch, server1_apps_response, server2_apps_response)
-
+    context = mock_context(event_name="cluster_apps_config")
     result = await client.get_apps_config(
         "http://test-server1,http://test-server2,http://test-server-error",
-        expand_events=False
+        context,
+        expand_events=False,
     )
 
     assert result.apps == cluster_apps_response.apps
@@ -47,3 +81,9 @@ async def test_client_ignore_hosts_errors(monkeypatch, cluster_apps_response,
         "http://test-server2": ServerStatus.ALIVE,
         "http://test-server-error": ServerStatus.ERROR,
     }
+
+
+def _init_engine_logger(mock_app_config):  # noqa: F811
+    logger = server_logging.engine_logger()
+    logger.init_server(mock_app_config.server)
+    logger.init_app(mock_app_config, plugins=[])

--- a/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
+++ b/plugins/ops/config-manager/test/integration/test_cluster_apps_config.py
@@ -6,16 +6,21 @@ from . import mock_client
 
 
 @pytest.mark.asyncio
-async def test_cluster_apps_config(monkeypatch, cluster_apps_response,
-                                   server1_apps_response, server2_apps_response):
-
+async def test_cluster_apps_config(
+    monkeypatch, cluster_apps_response, server1_apps_response, server2_apps_response
+):
     def apply_mock_client(module, context):
-        mock_client(module.client, monkeypatch, server1_apps_response, server2_apps_response)
+        mock_client(
+            module.client, monkeypatch, server1_apps_response, server2_apps_response
+        )
 
-    plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
+    plugin_config = config("plugins/ops/config-manager/config/plugin-config.json")
     result = await execute_event(
-        app_config=plugin_config, event_name="cluster_apps_config", payload=None,
-        mocks=[apply_mock_client], hosts="http://test-server1,http://test-server2"
+        app_config=plugin_config,
+        event_name="cluster_apps_config",
+        payload=None,
+        mocks=[apply_mock_client],
+        hosts="http://test-server1,http://test-server2",
     )
 
     assert result == cluster_apps_response
@@ -23,22 +28,25 @@ async def test_cluster_apps_config(monkeypatch, cluster_apps_response,
 
 @pytest.mark.asyncio
 async def test_cluster_apps_config_expand_events(
-    monkeypatch, effective_events_example,
-    server1_apps_response, server2_apps_response
+    monkeypatch, effective_events_example, server1_apps_response, server2_apps_response
 ):
-
     def apply_mock_client(module, context):
         mock_client(
-            module.client, monkeypatch,
-            server1_apps_response, server2_apps_response,
-            effective_events_example
+            module.client,
+            monkeypatch,
+            server1_apps_response,
+            server2_apps_response,
+            effective_events_example,
         )
 
-    plugin_config = config('plugins/ops/config-manager/config/plugin-config.json')
+    plugin_config = config("plugins/ops/config-manager/config/plugin-config.json")
     result = await execute_event(
-        app_config=plugin_config, event_name="cluster_apps_config", payload=None,
-        mocks=[apply_mock_client], hosts="http://test-server1,http://test-server2",
-        expand_events=True
+        app_config=plugin_config,
+        event_name="cluster_apps_config",
+        payload=None,
+        mocks=[apply_mock_client],
+        hosts="http://test-server1,http://test-server2",
+        expand_events=True,
     )
 
     for _, v in result.apps.items():


### PR DESCRIPTION
When the app-visualizer queries a locking server it waits indefinitely for a response. This leads to unresponsive front-end

Timeout need to be added here: https://github.com/hopeit-git/hopeit.engine/blob/master/plugins/ops/config-manager/src/hopeit/config_manager/client.py

closes #116 