### PR TITLE
fix(fs-storage): Large File Name RENAME ERROR (Win Error 3)

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -834,7 +834,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.21.2"
+            "default": "0.21.3"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2132,7 +2132,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.21.2"
+            "default": "0.21.3"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Version 0.21.3
+______________
+- Plugin:
+  
+  fs-storage: Resolved compatibility issues with long file names on Windows
+
+
 Version 0.21.2
 ______________
 - Engine:

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.21.2"
+ENGINE_VERSION = "0.21.3"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = '.'.join(ENGINE_VERSION.split('.')[0:2])

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -833,7 +833,7 @@
           },
           "engine_version": {
             "type": "string",
-            "default": "0.21.2"
+            "default": "0.21.3"
           }
         },
         "x-module-name": "hopeit.server.config",

--- a/plugins/storage/fs/src/hopeit/fs_storage/__init__.py
+++ b/plugins/storage/fs/src/hopeit/fs_storage/__init__.py
@@ -4,6 +4,7 @@ Storage/persistence asynchronous stores and gets dataobjects from filesystem.
 """
 from dataclasses import dataclass
 import os
+import shutil
 from glob import glob
 from pathlib import Path
 import uuid
@@ -166,5 +167,5 @@ class FileStorage(Generic[DataObject]):
         async with aiofiles.open(tmp_path, 'w') as f:  # type: ignore
             await f.write(payload_str)
             await f.flush()
-        os.rename(str(tmp_path), str(file_path))
+        shutil.move(str(tmp_path), str(file_path))
         return str(file_path)


### PR DESCRIPTION
Large File Name RENAME ERROR (Win Error 3) 

Using shutil.move instead of os.rename that does not work properly with long file names in windows.