### PR TITLE
plugin(dataframes): Dataframes schema evolution support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "simple-example",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "args": [
@@ -17,7 +17,7 @@
         },
         {
             "name": "simple-example-auto",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "args": [
@@ -31,7 +31,7 @@
         },
         {
             "name": "client-example",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "env": {
@@ -47,7 +47,7 @@
         },
         {
             "name": "dataframes-example",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "env": {
@@ -63,7 +63,7 @@
         },
         {
             "name": "apps-visualizer",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "env": {
@@ -80,7 +80,7 @@
         },
         {
             "name": "log-streamer",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "hopeit.server.web",
             "args": [

--- a/Makefile
+++ b/Makefile
@@ -110,21 +110,21 @@ test: test-engine test-plugins test-apps
 install:
 	cd engine && \
 	pip install --force-reinstall -r requirements.txt && \
-	pip install -U -e . --no-deps && \
-	pip install -U -e ".[web]" --no-deps && \
-	pip install -U -e ".[cli]" --no-deps
+	pip install -U -e . --no-deps --config-settings editable_mode=compat && \
+	pip install -U -e ".[web]" --no-deps --config-settings editable_mode=compat && \
+	pip install -U -e ".[cli]" --no-deps --config-settings editable_mode=compat
 
 install-app:
 	cd $(APPFOLDER) && \
-	pip install -U -e .
+	pip install -U -e . --config-settings editable_mode=compat
 
 install-plugin:
 	cd $(PLUGINFOLDER) && \
-	pip install -U -e .
+	pip install -U -e . --config-settings editable_mode=compat
 
 install-plugin-extras:
 	cd $(PLUGINFOLDER) && \
-	pip install -U -e .[$(PLUGINEXTRAS)]
+	pip install -U -e .[$(PLUGINEXTRAS)] --config-settings editable_mode=compat
 
 qa: test check
 	echo "DONE."

--- a/Makefile
+++ b/Makefile
@@ -110,21 +110,21 @@ test: test-engine test-plugins test-apps
 install:
 	cd engine && \
 	pip install --force-reinstall -r requirements.txt && \
-	pip install -U -e . --no-deps --config-settings editable_mode=compat && \
-	pip install -U -e ".[web]" --no-deps --config-settings editable_mode=compat && \
-	pip install -U -e ".[cli]" --no-deps --config-settings editable_mode=compat
+	pip install -U -e . --no-deps && \
+	pip install -U -e ".[web]" --no-deps && \
+	pip install -U -e ".[cli]" --no-deps
 
 install-app:
 	cd $(APPFOLDER) && \
-	pip install -U -e . --config-settings editable_mode=compat
+	pip install -U -e .
 
 install-plugin:
 	cd $(PLUGINFOLDER) && \
-	pip install -U -e . --config-settings editable_mode=compat
+	pip install -U -e .
 
 install-plugin-extras:
 	cd $(PLUGINFOLDER) && \
-	pip install -U -e .[$(PLUGINEXTRAS)] --config-settings editable_mode=compat
+	pip install -U -e .[$(PLUGINEXTRAS)]
 
 qa: test check
 	echo "DONE."

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -879,7 +879,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.0",
+            "default": "0.25.1",
             "title": "Engine Version",
             "type": "string"
           }

--- a/apps/examples/dataframes-example/api/openapi.json
+++ b/apps/examples/dataframes-example/api/openapi.json
@@ -1188,7 +1188,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.0",
+            "default": "0.25.1",
             "title": "Engine Version",
             "type": "string"
           }
@@ -1386,6 +1386,10 @@
           "datatype": {
             "title": "Datatype",
             "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "object"
           }
         },
         "required": [
@@ -1427,6 +1431,10 @@
           "datatype": {
             "title": "Datatype",
             "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "object"
           }
         },
         "required": [
@@ -1456,6 +1464,10 @@
           "datatype": {
             "title": "Datatype",
             "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "object"
           }
         },
         "required": [

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2185,7 +2185,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.0",
+            "default": "0.25.1",
             "title": "Engine Version",
             "type": "string"
           }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   # Redis needed for STREAM events
   redis:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+Version 0.25.1
+______________
+
+- Plugins:
+
+  - DataFrames:
+      - Saving json schema for serialiazed Datasets
+      - Handling load errors with `DatasetLoadException`
+
+
 Version 0.25.0
 ______________
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -6,7 +6,7 @@ ______________
 
 - Engine
 
-  - API: Support for `type | None`, as well as `Optional[type]` anottation for not required query args
+  - API: Support for `type | None` syntax, as well as `Optional[type]` annotation for optional required query args
 
 - Plugins:
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -4,11 +4,18 @@ Release Notes
 Version 0.25.1
 ______________
 
+- Engine
+
+  - API: Support for `type | None`, as well as `Optional[type]` anottation for not required query args
+
 - Plugins:
 
-  - DataFrames:
-      - Saving json schema for serialiazed Datasets
+  - DataFrames, feature to allow schema evolution:
+      - Allowing optional and default values in `@dataframe` objects
+      - Saving `json` schema for serialized Datasets
       - Handling load errors with `DatasetLoadException`
+      - Allowing load dataset with deprecated fields (removed fields)
+      - Allowing load dataset with new fields in schema using a default value
 
 
 Version 0.25.0

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -462,7 +462,7 @@
           "$ref": "#/$defs/APIConfig"
         },
         "engine_version": {
-          "default": "0.25.0",
+          "default": "0.25.1",
           "title": "Engine Version",
           "type": "string"
         }

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -164,7 +164,7 @@
       "$ref": "#/$defs/APIConfig"
     },
     "engine_version": {
-      "default": "0.25.0",
+      "default": "0.25.1",
       "title": "Engine Version",
       "type": "string"
     }

--- a/engine/src/hopeit/app/api.py
+++ b/engine/src/hopeit/app/api.py
@@ -86,9 +86,9 @@ def _arg_type(arg: ArgDef) -> Tuple[str, Optional[str], bool]:
     if isinstance(arg, str):
         return (*BUILTIN_TYPES[str], True)
     datatype, required = arg[1], True
+    type_args = typing_inspect.get_args(datatype)
     origin = typing_inspect.get_origin(datatype)
-    if origin is Union:
-        type_args = typing_inspect.get_args(datatype)
+    if len(type_args) and (origin is Union or type_args[-1] is type(None)):
         datatype = type_args[0]
         required = type_args[-1] is None
     return (*BUILTIN_TYPES.get(datatype, BUILTIN_TYPES[str]), required)

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.25.0"
+ENGINE_VERSION = "0.25.1"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = ".".join(ENGINE_VERSION.split(".")[0:2])

--- a/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
+++ b/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
@@ -64,7 +64,7 @@ class DatasetFileStorage(Generic[DataFrameT]):
         if data is None:
             raise FileNotFoundError(dataset.key)
         df = pd.read_parquet(io.BytesIO(data), engine="pyarrow")
-        return datatype._from_df(df, allow_new_fields=True)  # pylint: disable=protected-access
+        return datatype._from_df(df)  # pylint: disable=protected-access
 
 
 def find_dataframe_type(qual_type_name: str) -> Type[DataFrameT]:

--- a/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
+++ b/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
@@ -6,6 +6,7 @@ from typing import Generic, Optional, Type, TypeVar
 from uuid import uuid4
 
 import pandas as pd
+from pydantic import TypeAdapter
 
 try:
     import pyarrow  # type: ignore  # noqa  # pylint: disable=unused-import
@@ -53,6 +54,7 @@ class DatasetFileStorage(Generic[DataFrameT]):
             partition_key=partition_key,
             key=key,
             datatype=f"{datatype.__module__}.{datatype.__qualname__}",
+            schema=TypeAdapter(datatype).json_schema(),
         )
 
     async def load(self, dataset: Dataset) -> EventPayloadType:

--- a/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
+++ b/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
@@ -64,7 +64,7 @@ class DatasetFileStorage(Generic[DataFrameT]):
         if data is None:
             raise FileNotFoundError(dataset.key)
         df = pd.read_parquet(io.BytesIO(data), engine="pyarrow")
-        return datatype._from_df(df)  # pylint: disable=protected-access
+        return datatype._from_df(df, allow_new_fields=True)  # pylint: disable=protected-access
 
 
 def find_dataframe_type(qual_type_name: str) -> Type[DataFrameT]:

--- a/plugins/data/dataframes/test/integration/conftest.py
+++ b/plugins/data/dataframes/test/integration/conftest.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timezone
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 import pytest
@@ -12,7 +12,7 @@ from hopeit.app.config import (
 )
 from hopeit.app.context import EventContext
 from hopeit.dataframes import Dataset, dataframe
-from hopeit.dataobjects import dataclass, dataobject
+from hopeit.dataobjects import dataclass, dataobject, field
 from hopeit.testing.apps import create_test_context, execute_event, server_config
 
 
@@ -26,9 +26,32 @@ class MyTestData:
 
 @dataframe
 @dataclass
+class MyTestDataOptionalValues:
+    number: int
+    name: str
+    timestamp: datetime
+    optional_value: Optional[float]
+    optional_label: Optional[str]
+
+
+@dataframe
+@dataclass
+class MyTestDataDefaultValues:
+    number: int
+    name: str
+    timestamp: datetime
+    optional_value: Optional[float] = 0.0
+    optional_label: Optional[str] = "(default)"
+
+
+@dataframe
+@dataclass
 class MyTestDataSchemaCompatible:
     number: int
+    # Removed field: name
     timestamp: datetime
+    # Added field with default value
+    new_optional_field: str = field(default="(default)")
 
 
 @dataframe
@@ -76,6 +99,31 @@ class MyTestAllTypesData:
     str_value: str
     date_value: date
     datetime_value: datetime
+    int_value_optional: Optional[int]
+    float_value_optional: Optional[float]
+    str_value_optional: Optional[str]
+    date_value_optional: Optional[date]
+    datetime_value_optional: Optional[datetime]
+
+
+DEFAULT_DATE = datetime.now().date()
+DEFAULT_DATETIME = datetime.now(tz=timezone.utc)
+
+
+@dataframe
+@dataclass
+class MyTestAllTypesDefaultValues:
+    id: str
+    int_value: int = 1
+    float_value: float = 1.0
+    str_value: str = "(default)"
+    date_value: date = DEFAULT_DATE
+    datetime_value: datetime = DEFAULT_DATETIME
+    int_value_optional: Optional[int] = None
+    float_value_optional: Optional[float] = None
+    str_value_optional: Optional[str] = None
+    date_value_optional: Optional[date] = None
+    datetime_value_optional: Optional[datetime] = None
 
 
 @pytest.fixture

--- a/plugins/data/dataframes/test/integration/conftest.py
+++ b/plugins/data/dataframes/test/integration/conftest.py
@@ -26,6 +26,22 @@ class MyTestData:
 
 @dataframe
 @dataclass
+class MyTestDataSchemaCompatible:
+    number: int
+    timestamp: datetime
+
+
+@dataframe
+@dataclass
+class MyTestDataSchemaNotCompatible:
+    number: int
+    name: str
+    timestamp: datetime
+    new_required_field: str
+
+
+@dataframe
+@dataclass
 class MyNumericalData:
     number: int
     value: float

--- a/plugins/data/dataframes/test/integration/test_dataframe.py
+++ b/plugins/data/dataframes/test/integration/test_dataframe.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from conftest import MyTestAllTypesData
+from conftest import DEFAULT_DATE, DEFAULT_DATETIME, MyTestAllTypesData, MyTestAllTypesDefaultValues
 
 
 def test_coerce_types_happy():
@@ -12,14 +12,16 @@ def test_coerce_types_happy():
     test_datetime = datetime.now(tz=timezone.utc)
 
     data = MyTestAllTypesData(
-        int_value=[0, 1, 2.5],
+        int_value=[0, 1, 2],
         float_value=[1.1, 2.2, 3],
         str_value=["a", "B", 42],
         date_value=[test_date, test_date, "2024-01-01"],
         datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
-        float_value_opt=[1.1, 2.2, None],
-        date_value_opt=[test_date, None, None],
-        datetime_value_opt=[test_datetime, test_datetime, None],
+        int_value_optional=[0, 1, None],
+        float_value_optional=[1.1, 2.2, None],
+        str_value_optional=["a", "B", None],
+        date_value_optional=[test_date, None, None],
+        datetime_value_optional=[test_datetime, test_datetime, None],
     )
 
     pd.testing.assert_series_equal(data.int_value, pd.Series([0, 1, 2], name="int_value"))
@@ -47,69 +49,196 @@ def test_coerce_types_happy():
             name="datetime_value",
         ),
     )
-
-
-def test_coerce_types_none_values():
-    test_date = datetime.now().date()
-    test_datetime = datetime.now(tz=timezone.utc)
-
-    data = MyTestAllTypesData(
-        int_value=[0, 1, 2.5],
-        str_value=["a", "B", None],
-        float_value=[1.1, 2.2, None],
-        date_value=[test_date, None, None],
-        datetime_value=[test_datetime, test_datetime, None],
+    pd.testing.assert_series_equal(
+        data.int_value_optional, pd.Series([0, 1, np.nan], name="int_value_optional")
     )
     pd.testing.assert_series_equal(
-        data.float_value, pd.Series([1.1, 2.2, np.nan], name="float_value")
-    )
-    pd.testing.assert_series_equal(data.str_value, pd.Series(["a", "B", "None"], name="str_value"))
-    pd.testing.assert_series_equal(
-        data.date_value,
-        pd.Series([pd.Timestamp(test_date), pd.NaT, pd.NaT], name="date_value"),
+        data.float_value_optional, pd.Series([1.1, 2.2, np.nan], name="float_value_optional")
     )
     pd.testing.assert_series_equal(
-        data.datetime_value,
+        data.str_value_optional, pd.Series(["a", "B", np.nan], name="str_value_optional")
+    )
+    pd.testing.assert_series_equal(
+        data.date_value_optional,
         pd.Series(
-            [pd.Timestamp(test_datetime), pd.Timestamp(test_datetime), pd.NaT],
-            name="datetime_value",
+            [
+                pd.Timestamp(test_date),
+                pd.NaT,
+                pd.NaT,
+            ],
+            name="date_value_optional",
+        ),
+    )
+    pd.testing.assert_series_equal(
+        data.datetime_value_optional,
+        pd.Series(
+            [
+                pd.Timestamp(test_datetime),
+                pd.Timestamp(test_datetime),
+                pd.NaT,
+            ],
+            name="datetime_value_optional",
         ),
     )
 
 
 def test_coerce_types_defaults():
-    data = MyTestAllTypesData(
-        int_value=[0, 1, 2.5],
-        float_value=None,
-        str_value=None,
-        date_value=None,
-        datetime_value=None,
+    data = MyTestAllTypesDefaultValues(id=["1", "2", "3"])
+    pd.testing.assert_series_equal(
+        data.int_value,
+        pd.Series([1, 1, 1], name="int_value"),
     )
-
     pd.testing.assert_series_equal(
         data.float_value,
-        pd.Series([np.nan, np.nan, np.nan], name="float_value"),
+        pd.Series([1.0, 1.0, 1.0], name="float_value"),
     )
     pd.testing.assert_series_equal(
-        data.str_value, pd.Series(["None", "None", "None"], name="str_value")
+        data.str_value,
+        pd.Series(["(default)", "(default)", "(default)"], name="str_value", dtype="object"),
     )
     pd.testing.assert_series_equal(
         data.date_value,
-        pd.Series([pd.NaT, pd.NaT, pd.NaT], name="date_value"),
+        pd.Series(
+            [DEFAULT_DATE, DEFAULT_DATE, DEFAULT_DATE], name="date_value", dtype="datetime64[ns]"
+        ),
     )
     pd.testing.assert_series_equal(
         data.datetime_value,
-        pd.Series([pd.NaT, pd.NaT, pd.NaT], name="datetime_value", dtype="datetime64[ns, UTC]"),
+        pd.Series(
+            [DEFAULT_DATETIME, DEFAULT_DATETIME, DEFAULT_DATETIME],
+            name="datetime_value",
+            dtype="datetime64[ns, UTC]",
+        ),
+    )
+    pd.testing.assert_series_equal(
+        data.float_value_optional,
+        pd.Series([np.nan, np.nan, np.nan], name="float_value_optional"),
+    )
+    pd.testing.assert_series_equal(
+        data.str_value_optional,
+        pd.Series([np.nan, np.nan, np.nan], name="str_value_optional", dtype="object"),
+    )
+    pd.testing.assert_series_equal(
+        data.date_value_optional,
+        pd.Series([pd.NaT, pd.NaT, pd.NaT], name="date_value_optional", dtype="datetime64[ns]"),
+    )
+    pd.testing.assert_series_equal(
+        data.datetime_value_optional,
+        pd.Series(
+            [pd.NaT, pd.NaT, pd.NaT], name="datetime_value_optional", dtype="datetime64[ns, UTC]"
+        ),
     )
 
 
-def test_coerce_types_unhappy():
+def test_coerce_types_none_to_defaults():
+    data = MyTestAllTypesDefaultValues(
+        id=["1", "2", "3"],
+        int_value_optional=None,
+        float_value_optional=None,
+        str_value_optional=None,
+        date_value_optional=None,
+        datetime_value_optional=None,
+    )
+    pd.testing.assert_series_equal(
+        data.int_value,
+        pd.Series([1, 1, 1], name="int_value"),
+    )
+    pd.testing.assert_series_equal(
+        data.float_value,
+        pd.Series([1.0, 1.0, 1.0], name="float_value"),
+    )
+    pd.testing.assert_series_equal(
+        data.str_value,
+        pd.Series(["(default)", "(default)", "(default)"], name="str_value", dtype="object"),
+    )
+    pd.testing.assert_series_equal(
+        data.date_value,
+        pd.Series(
+            [DEFAULT_DATE, DEFAULT_DATE, DEFAULT_DATE], name="date_value", dtype="datetime64[ns]"
+        ),
+    )
+    pd.testing.assert_series_equal(
+        data.datetime_value,
+        pd.Series(
+            [DEFAULT_DATETIME, DEFAULT_DATETIME, DEFAULT_DATETIME],
+            name="datetime_value",
+            dtype="datetime64[ns, UTC]",
+        ),
+    )
+    pd.testing.assert_series_equal(
+        data.float_value_optional,
+        pd.Series([np.nan, np.nan, np.nan], name="float_value_optional"),
+    )
+    pd.testing.assert_series_equal(
+        data.str_value_optional,
+        pd.Series([np.nan, np.nan, np.nan], name="str_value_optional", dtype="object"),
+    )
+    pd.testing.assert_series_equal(
+        data.date_value_optional,
+        pd.Series([pd.NaT, pd.NaT, pd.NaT], name="date_value_optional", dtype="datetime64[ns]"),
+    )
+    pd.testing.assert_series_equal(
+        data.datetime_value_optional,
+        pd.Series(
+            [pd.NaT, pd.NaT, pd.NaT], name="datetime_value_optional", dtype="datetime64[ns, UTC]"
+        ),
+    )
+
+
+def test_coerce_types_unhappy_bad_types():
+    test_date = datetime.now().date()
+    test_datetime = datetime.now(tz=timezone.utc)
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            int_value=[0, 1, "a"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            float_value=[1.1, 2.2, "a"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            date_value=[test_date, test_date, "invalid-date"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            datetime_value=[test_datetime, test_datetime, "invalid-date"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            int_value=None,
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            float_value=None,
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesDefaultValues(
+            id=["1", "2", "3"],
+            str_value=None,
+        )
+
+
+def test_coerce_types_unhappy_none_fields():
     test_date = datetime.now().date()
     test_datetime = datetime.now(tz=timezone.utc)
 
     with pytest.raises(ValueError):
         MyTestAllTypesData(
-            int_value=[0, 1, "a"],
+            int_value=None,
             float_value=[1.1, 2.2, 3],
             str_value=["a", "B", 42],
             date_value=[test_date, test_date, "2024-01-01"],
@@ -118,8 +247,8 @@ def test_coerce_types_unhappy():
 
     with pytest.raises(ValueError):
         MyTestAllTypesData(
-            int_value=[0, 1, 2.5],
-            float_value=[1.1, 2.2, "a"],
+            int_value=[1, 2, 3],
+            float_value=None,
             str_value=["a", "B", 42],
             date_value=[test_date, test_date, "2024-01-01"],
             datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
@@ -127,27 +256,122 @@ def test_coerce_types_unhappy():
 
     with pytest.raises(ValueError):
         MyTestAllTypesData(
-            int_value=[0, 1, 2.5],
-            float_value=[1.1, 2.2, 3.3],
-            str_value=["a", "B", 42],
-            date_value=[test_date, test_date, "invalid-date"],
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=None,
+            date_value=[test_date, test_date, "2024-01-01"],
             datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
         )
 
     with pytest.raises(ValueError):
         MyTestAllTypesData(
-            int_value=[0, 1, 2.5],
-            float_value=[1.1, 2.2, 3.3],
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
             str_value=["a", "B", 42],
-            date_value=[test_date, test_date, test_date],
-            datetime_value=[test_datetime, test_datetime, "invalid-date"],
+            date_value=None,
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         MyTestAllTypesData(
-            int_value=None,
-            float_value=[1.1, 2.2, 3.3],
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
             str_value=["a", "B", 42],
-            date_value=[test_date, test_date, test_date],
-            datetime_value=[test_datetime, test_datetime, test_datetime],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=None,
+        )
+
+
+def test_coerce_types_unhappy_none_values():
+    test_date = datetime.now().date()
+    test_datetime = datetime.now(tz=timezone.utc)
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesData(
+            int_value=[1, 2, None],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, None],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "b", None],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, None],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(ValueError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, None, None],
+        )
+
+
+def test_coerce_types_unhappy_missing_fields():
+    test_date = datetime.now().date()
+    test_datetime = datetime.now(tz=timezone.utc)
+
+    with pytest.raises(KeyError):
+        MyTestAllTypesData(
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(KeyError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(KeyError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            date_value=[test_date, test_date, "2024-01-01"],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(KeyError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        )
+
+    with pytest.raises(KeyError):
+        MyTestAllTypesData(
+            int_value=[1, 2, 3],
+            float_value=[1.1, 2.2, 3],
+            str_value=["a", "B", 42],
+            date_value=[test_date, test_date, "2024-01-01"],
         )

--- a/plugins/data/dataframes/test/integration/test_dataframes_api.py
+++ b/plugins/data/dataframes/test/integration/test_dataframes_api.py
@@ -9,6 +9,8 @@ from conftest import (
     MyNumericalData,
     MyPartialTestData,
     MyTestData,
+    MyTestDataOptionalValues,
+    MyTestDataDefaultValues,
     MyTestDataObject,
     MyTestDataSchemaCompatible,
     MyTestDataSchemaNotCompatible,
@@ -23,6 +25,58 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 def test_dataframes_from_df(sample_pandas_df: pd.DataFrame):
     initial_data = DataFrames.from_df(MyTestData, sample_pandas_df)
     assert len(DataFrames.df(initial_data)) == 100
+
+
+def test_dataframes_from_df_not_nullable_number(sample_pandas_df: pd.DataFrame):
+    sample_pandas_df.loc[0, "number"] = np.nan
+    with pytest.raises(ValueError):
+        DataFrames.from_df(MyTestData, sample_pandas_df)
+
+
+def test_dataframes_from_df_not_nullable_string(sample_pandas_df: pd.DataFrame):
+    sample_pandas_df.loc[0, "name"] = np.nan
+    with pytest.raises(ValueError):
+        DataFrames.from_df(MyTestData, sample_pandas_df)
+
+
+def test_dataframes_from_df_all_null_values(sample_pandas_df: pd.DataFrame):
+    sample_pandas_df["optional_value"] = np.nan
+    sample_pandas_df["optional_label"] = np.nan
+    initial_data = DataFrames.from_df(MyTestDataOptionalValues, sample_pandas_df)
+    assert len(DataFrames.df(initial_data)) == 100
+    assert initial_data.optional_value.isnull().all()  # type: ignore[union-attr]
+    assert initial_data.optional_label.isnull().all()  # type: ignore[union-attr]
+
+
+def test_dataframes_from_df_some_null_values(sample_pandas_df: pd.DataFrame):
+    sample_pandas_df["optional_value"] = 100.0
+    sample_pandas_df["optional_label"] = "optional"
+    sample_pandas_df.loc[1, "optional_value"] = np.nan
+    sample_pandas_df.loc[2, "optional_label"] = np.nan
+    initial_data = DataFrames.from_df(MyTestDataOptionalValues, sample_pandas_df)
+    assert len(DataFrames.df(initial_data)) == 100
+    assert initial_data.optional_value.loc[0] == 100.0  # type: ignore[union-attr]
+    assert np.isnan(initial_data.optional_value.loc[1])  # type: ignore[union-attr]
+    assert initial_data.optional_value.loc[2] == 100.0  # type: ignore[union-attr]
+    assert initial_data.optional_label.loc[1] == "optional"  # type: ignore[union-attr]
+    assert np.isnan(initial_data.optional_label.loc[2])  # type: ignore[union-attr]
+    assert initial_data.optional_label.loc[3] == "optional"  # type: ignore[union-attr]
+
+
+def test_dataframes_from_df_set_optional_values(sample_pandas_df: pd.DataFrame):
+    sample_pandas_df["optional_value"] = 100.0
+    sample_pandas_df["optional_label"] = "optional"
+    initial_data = DataFrames.from_df(MyTestDataOptionalValues, sample_pandas_df)
+    assert len(DataFrames.df(initial_data)) == 100
+    assert (initial_data.optional_value == 100.0).all()  # type: ignore[union-attr, attr-defined]
+    assert (initial_data.optional_label == "optional").all()  # type: ignore[union-attr, attr-defined]
+
+
+def test_dataframes_from_df_default_values(sample_pandas_df: pd.DataFrame):
+    initial_data = DataFrames.from_df(MyTestDataDefaultValues, sample_pandas_df)
+    assert len(DataFrames.df(initial_data)) == 100
+    assert (initial_data.optional_value == 0.0).all()  # type: ignore[union-attr, attr-defined]
+    assert (initial_data.optional_label == "(default)").all()  # type: ignore[union-attr, attr-defined]
 
 
 def test_dataframes_from_dataframe(sample_pandas_df: pd.DataFrame):
@@ -88,8 +142,11 @@ async def test_dataframe_dataset_deserialization_compatible(
     modified_obj.datatype = "conftest.MyTestDataSchemaCompatible"
     loaded_obj = await modified_obj.load()
 
+    expected_df = DataFrames.df(initial_data)
+    expected_df["new_optional_field"] = "(default)"
+
     assert_frame_equal(
-        DataFrames.df(initial_data)[["number", "timestamp"]], DataFrames.df(loaded_obj)
+        expected_df[["number", "timestamp", "new_optional_field"]], DataFrames.df(loaded_obj)
     )
 
 

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -878,7 +878,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.0",
+            "default": "0.25.1",
             "title": "Engine Version",
             "type": "string"
           }


### PR DESCRIPTION
- [x] Saving json schema with serialized Datasets to track schema evolution.
- [x] Allows load dataset with deprecated fields (removed fields)
- [x] Allow load dataset with new fields in schema using a default value
- [x] Allow optional values 