### PR TITLE
fix(dataframes): dataframes datetime type mapping & boolean support

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -879,7 +879,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.1",
+            "default": "0.25.2",
             "title": "Engine Version",
             "type": "string"
           }

--- a/apps/examples/dataframes-example/api/openapi.json
+++ b/apps/examples/dataframes-example/api/openapi.json
@@ -1188,7 +1188,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.1",
+            "default": "0.25.2",
             "title": "Engine Version",
             "type": "string"
           }

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2185,7 +2185,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.1",
+            "default": "0.25.2",
             "title": "Engine Version",
             "type": "string"
           }

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,9 +1,18 @@
 Release Notes
 =============
 
-Version 0.25.1
+Version 0.25.2
 ______________
 
+- Plugins:
+
+  - DataFrames:
+    - Support for `bool` fields
+    - `Dataframes.to_dataobjects`: option to convert null values (`nan`, `NaT`, etc) to None
+
+
+Version 0.25.1
+______________
 - Engine
 
   - API: Support for `type | None` syntax, as well as `Optional[type]` annotation for optional required query args

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -462,7 +462,7 @@
           "$ref": "#/$defs/APIConfig"
         },
         "engine_version": {
-          "default": "0.25.1",
+          "default": "0.25.2",
           "title": "Engine Version",
           "type": "string"
         }

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -164,7 +164,7 @@
       "$ref": "#/$defs/APIConfig"
     },
     "engine_version": {
-      "default": "0.25.1",
+      "default": "0.25.2",
       "title": "Engine Version",
       "type": "string"
     }

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.25.1"
+ENGINE_VERSION = "0.25.2"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = ".".join(ENGINE_VERSION.split(".")[0:2])

--- a/engine/test/unit/server/test_server.py
+++ b/engine/test/unit/server/test_server.py
@@ -2,7 +2,7 @@ import pytest  # type: ignore
 
 from hopeit.app.config import AppConfig
 from hopeit.server import runtime
-from hopeit.server.engine import Server, AppEngine
+from hopeit.server import engine
 
 
 from mock_app import mock_app_config  # type: ignore
@@ -10,7 +10,7 @@ from mock_plugin import mock_plugin_config  # type: ignore
 from mock_engine import MockAppEngine
 
 
-async def start_server(app_config: AppConfig, plugin: AppConfig) -> Server:
+async def start_server(app_config: AppConfig, plugin: AppConfig) -> engine.Server:
     assert app_config.server
     server = await runtime.server.start(config=app_config.server)
     await server.start_app(app_config=plugin, enabled_groups=[])
@@ -20,9 +20,7 @@ async def start_server(app_config: AppConfig, plugin: AppConfig) -> Server:
 
 @pytest.mark.asyncio
 async def test_app_start(monkeypatch, mock_app_config, mock_plugin_config):
-    monkeypatch.setattr(AppEngine, "__init__", MockAppEngine.__init__)
-    monkeypatch.setattr(AppEngine, "start", MockAppEngine.start)
-    monkeypatch.setattr(AppEngine, "stop", MockAppEngine.stop)
+    monkeypatch.setattr(engine, "AppEngine", MockAppEngine)
     server = await start_server(mock_app_config, mock_plugin_config)
     assert server.app_engine(app_key="mock_app.test").app_config == mock_app_config
     assert server.app_engine(app_key="mock_plugin.test").app_config == mock_plugin_config

--- a/engine/test/unit/server/test_web.py
+++ b/engine/test/unit/server/test_web.py
@@ -152,7 +152,7 @@ async def test_server_initialization(monkeypatch, api_file, api_auto):
         web.web_server.on_startup.append(_shutdown)
         web.web.run_app(web.web_server, host="localhost", port=8020, path=None)
 
-    async with test_lock:
+    async with test_lock:  # Ensures this part does not run concurrently
         nest_asyncio.apply()
 
         _load_engine_config = MagicMock()

--- a/plugins/data/dataframes/src/hopeit/dataframes/__init__.py
+++ b/plugins/data/dataframes/src/hopeit/dataframes/__init__.py
@@ -118,9 +118,9 @@ class DataFrames(Generic[DataFrameT, DataObject]):
         return datatype._from_dataobjects(dataobjects)  # type: ignore  # pylint: disable=protected-access
 
     @staticmethod
-    def to_dataobjects(obj: DataFrameT) -> List[DataObject]:
+    def to_dataobjects(obj: DataFrameT, *, normalize_null_values: bool = False) -> List[DataObject]:
         """Converts `@dataframe` object to a list of standard `@dataobject`s"""
-        return obj._to_dataobjects()  # type: ignore  # pylint: disable=protected-access
+        return obj._to_dataobjects(normalize_null_values)  # type: ignore  # pylint: disable=protected-access
 
     @staticmethod
     def from_array(datatype: Type[DataFrameT], array: np.ndarray) -> DataFrameT:

--- a/plugins/data/dataframes/test/integration/conftest.py
+++ b/plugins/data/dataframes/test/integration/conftest.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timezone
 from typing import List, Optional
 
+import numpy as np
 import pandas as pd
 import pytest
 from hopeit.app.config import (
@@ -22,6 +23,15 @@ class MyTestData:
     number: int
     name: str
     timestamp: datetime
+
+
+@dataframe
+@dataclass
+class MyTestDataAllOptional:
+    id: str
+    number: Optional[int]
+    name: Optional[str]
+    timestamp: Optional[datetime]
 
 
 @dataframe
@@ -99,11 +109,13 @@ class MyTestAllTypesData:
     str_value: str
     date_value: date
     datetime_value: datetime
+    bool_value: bool
     int_value_optional: Optional[int]
     float_value_optional: Optional[float]
     str_value_optional: Optional[str]
     date_value_optional: Optional[date]
     datetime_value_optional: Optional[datetime]
+    bool_value_optional: Optional[bool]
 
 
 DEFAULT_DATE = datetime.now().date()
@@ -119,11 +131,13 @@ class MyTestAllTypesDefaultValues:
     str_value: str = "(default)"
     date_value: date = DEFAULT_DATE
     datetime_value: datetime = DEFAULT_DATETIME
+    bool_value: bool = False
     int_value_optional: Optional[int] = None
     float_value_optional: Optional[float] = None
     str_value_optional: Optional[str] = None
     date_value_optional: Optional[date] = None
     datetime_value_optional: Optional[datetime] = None
+    bool_value_optional: Optional[bool] = None
 
 
 @pytest.fixture
@@ -135,6 +149,21 @@ def one_element_pandas_df() -> pd.DataFrame:
                 "name": "test1",
                 "timestamp": datetime.now(tz=timezone.utc),
             }
+        ]
+    )
+
+
+@pytest.fixture
+def two_element_pandas_df_with_nulls() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "id": "1",
+                "number": 1,
+                "name": "test1",
+                "timestamp": datetime.now(tz=timezone.utc),
+            },
+            {"id": "2", "number": np.nan, "name": None, "timestamp": pd.NaT},
         ]
     )
 

--- a/plugins/data/dataframes/test/integration/test_dataframe.py
+++ b/plugins/data/dataframes/test/integration/test_dataframe.py
@@ -17,11 +17,13 @@ def test_coerce_types_happy():
         str_value=["a", "B", 42],
         date_value=[test_date, test_date, "2024-01-01"],
         datetime_value=[test_datetime, test_datetime, "2024-01-01T00:00:00Z"],
+        bool_value=[True, False, True],
         int_value_optional=[0, 1, None],
         float_value_optional=[1.1, 2.2, None],
         str_value_optional=["a", "B", None],
         date_value_optional=[test_date, None, None],
         datetime_value_optional=[test_datetime, test_datetime, None],
+        bool_value_optional=[True, False, None],
     )
 
     pd.testing.assert_series_equal(data.int_value, pd.Series([0, 1, 2], name="int_value"))
@@ -48,6 +50,9 @@ def test_coerce_types_happy():
             ],
             name="datetime_value",
         ),
+    )
+    pd.testing.assert_series_equal(
+        data.bool_value, pd.Series([True, False, True], name="bool_value")
     )
     pd.testing.assert_series_equal(
         data.int_value_optional, pd.Series([0, 1, np.nan], name="int_value_optional")
@@ -80,6 +85,9 @@ def test_coerce_types_happy():
             name="datetime_value_optional",
         ),
     )
+    pd.testing.assert_series_equal(
+        data.bool_value_optional, pd.Series([True, False, None], name="bool_value_optional")
+    )
 
 
 def test_coerce_types_defaults():
@@ -111,6 +119,9 @@ def test_coerce_types_defaults():
         ),
     )
     pd.testing.assert_series_equal(
+        data.bool_value, pd.Series([False, False, False], name="bool_value")
+    )
+    pd.testing.assert_series_equal(
         data.float_value_optional,
         pd.Series([np.nan, np.nan, np.nan], name="float_value_optional"),
     )
@@ -127,6 +138,9 @@ def test_coerce_types_defaults():
         pd.Series(
             [pd.NaT, pd.NaT, pd.NaT], name="datetime_value_optional", dtype="datetime64[ns, UTC]"
         ),
+    )
+    pd.testing.assert_series_equal(
+        data.bool_value_optional, pd.Series([None, None, None], name="bool_value_optional")
     )
 
 

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -878,7 +878,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.1",
+            "default": "0.25.2",
             "title": "Engine Version",
             "type": "string"
           }


### PR DESCRIPTION
Version 0.25.2
______________

- Plugins:

  - DataFrames:
    - Support for `bool` fields
    - `Dataframes.to_dataobjects`: option to convert null values (`nan`, `NaT`, etc) to None