### PR TITLE
Allow to specify cors_routes_prefix to allow cors_origin to be applied  to custom route names

### DIFF
--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -529,7 +529,7 @@
         "type": "object"
       },
       "AppEngineConfig": {
-        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server",
+        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server\n:cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used",
         "properties": {
           "import_modules": {
             "default": null,
@@ -569,6 +569,12 @@
             "default": null,
             "nullable": true,
             "title": "Cors Origin",
+            "type": "string"
+          },
+          "cors_routes_prefix": {
+            "default": null,
+            "nullable": true,
+            "title": "Cors Routes Prefix",
             "type": "string"
           }
         },
@@ -879,7 +885,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.2",
+            "default": "0.25.3",
             "title": "Engine Version",
             "type": "string"
           }

--- a/apps/examples/dataframes-example/api/openapi.json
+++ b/apps/examples/dataframes-example/api/openapi.json
@@ -838,7 +838,7 @@
         "type": "object"
       },
       "AppEngineConfig": {
-        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server",
+        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server\n:cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used",
         "properties": {
           "import_modules": {
             "default": null,
@@ -878,6 +878,12 @@
             "default": null,
             "nullable": true,
             "title": "Cors Origin",
+            "type": "string"
+          },
+          "cors_routes_prefix": {
+            "default": null,
+            "nullable": true,
+            "title": "Cors Routes Prefix",
             "type": "string"
           }
         },
@@ -1188,7 +1194,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.2",
+            "default": "0.25.3",
             "title": "Engine Version",
             "type": "string"
           }

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1835,7 +1835,7 @@
         "type": "object"
       },
       "AppEngineConfig": {
-        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server",
+        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server\n:cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used",
         "properties": {
           "import_modules": {
             "default": null,
@@ -1875,6 +1875,12 @@
             "default": null,
             "nullable": true,
             "title": "Cors Origin",
+            "type": "string"
+          },
+          "cors_routes_prefix": {
+            "default": null,
+            "nullable": true,
+            "title": "Cors Routes Prefix",
             "type": "string"
           }
         },
@@ -2185,7 +2191,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.2",
+            "default": "0.25.3",
             "title": "Engine Version",
             "type": "string"
           }

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,7 +1,17 @@
 Release Notes
 =============
 
-Version 0.25.2
+Version 0.25.3
+______________
+
+- Engine:
+
+  - Web:
+    - Allow to specify `cors_routes_prefix` to allow `cors_origin` to be applied
+    to custom routes names
+
+
+Version 0.25.3
 ______________
 
 - Plugins:

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -99,7 +99,7 @@
       "type": "object"
     },
     "AppEngineConfig": {
-      "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server",
+      "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server\n:cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used",
       "properties": {
         "import_modules": {
           "anyOf": [
@@ -152,6 +152,18 @@
           ],
           "default": null,
           "title": "Cors Origin"
+        },
+        "cors_routes_prefix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cors Routes Prefix"
         }
       },
       "title": "AppEngineConfig",
@@ -462,7 +474,7 @@
           "$ref": "#/$defs/APIConfig"
         },
         "engine_version": {
-          "default": "0.25.2",
+          "default": "0.25.3",
           "title": "Engine Version",
           "type": "string"
         }

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -164,7 +164,7 @@
       "$ref": "#/$defs/APIConfig"
     },
     "engine_version": {
-      "default": "0.25.2",
+      "default": "0.25.3",
       "title": "Engine Version",
       "type": "string"
     }

--- a/engine/src/hopeit/app/config.py
+++ b/engine/src/hopeit/app/config.py
@@ -384,6 +384,7 @@ class AppEngineConfig:
         connection pool to be blocked constantly.
     :track_headers: list of required X-Track-* headers
     :cors_origin: allowed CORS origin for web server
+    :cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used
     """
 
     import_modules: Optional[List[str]] = None
@@ -393,6 +394,7 @@ class AppEngineConfig:
     default_stream_serialization: Serialization = Serialization.JSON_BASE64
     track_headers: List[str] = field(default_factory=list)
     cors_origin: Optional[str] = None
+    cors_routes_prefix: Optional[str] = None
 
     def __post_init__(self):
         self.track_headers = [

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.25.2"
+ENGINE_VERSION = "0.25.3"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = ".".join(ENGINE_VERSION.split(".")[0:2])

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -190,10 +190,10 @@ async def app_startup_hook(config: AppConfig, enabled_groups: List[str], *args, 
         await _setup_app_event_routes(app_engine, plugin_engine)
     if cors_origin:
         app = app_engine.app_config.app
-        cors_route_prefix = app_engine.app_config.engine.cors_routes_prefix
-        if cors_route_prefix is None:
-            cors_route_prefix = route_name("api", app.name, app.version)
-        _enable_cors(cors_route_prefix, cors_origin)
+        cors_prefix = app_engine.app_config.engine.cors_routes_prefix
+        if cors_prefix is None:
+            cors_prefix = route_name("api", app.name, app.version)
+        _enable_cors(cors_prefix, cors_origin)
 
 
 async def stream_startup_hook(app_config: AppConfig, *args, **kwargs):

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -190,7 +190,10 @@ async def app_startup_hook(config: AppConfig, enabled_groups: List[str], *args, 
         await _setup_app_event_routes(app_engine, plugin_engine)
     if cors_origin:
         app = app_engine.app_config.app
-        _enable_cors(route_name("api", app.name, app.version), cors_origin)
+        cors_route_prefix = app_engine.app_config.engine.cors_routes_prefix
+        if cors_route_prefix is None:
+            cors_route_prefix = route_name("api", app.name, app.version)
+        _enable_cors(cors_route_prefix, cors_origin)
 
 
 async def stream_startup_hook(app_config: AppConfig, *args, **kwargs):

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -528,7 +528,7 @@
         "type": "object"
       },
       "AppEngineConfig": {
-        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server",
+        "description": "Engine specific parameters shared among events\n\n:field import_modules: list of string with the python module names to import to find\n    events and datatype implementations\n:field read_stream_timeout: timeout in milliseconds to block connection pool when waiting for stream events\n:field read_stream_interval: delay in milliseconds to wait before attempting a new batch. Use to prevent\n    connection pool to be blocked constantly.\n:track_headers: list of required X-Track-* headers\n:cors_origin: allowed CORS origin for web server\n:cors_routes_prefix: routes prefix to apply CORS origin to. If not specified `/api/app-name/version/` will be used",
         "properties": {
           "import_modules": {
             "default": null,
@@ -568,6 +568,12 @@
             "default": null,
             "nullable": true,
             "title": "Cors Origin",
+            "type": "string"
+          },
+          "cors_routes_prefix": {
+            "default": null,
+            "nullable": true,
+            "title": "Cors Routes Prefix",
             "type": "string"
           }
         },
@@ -878,7 +884,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.25.2",
+            "default": "0.25.3",
             "title": "Engine Version",
             "type": "string"
           }


### PR DESCRIPTION
Version 0.25.3
______________

- Engine:

  - Web:
    - Allow to specify `cors_routes_prefix` to allow `cors_origin` to be applied
    to custom routes names