### PR TITLE
chore(deps): unpinned aiohttp 3 after aiohttp-swagger 0.10 release

### DIFF
--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -946,6 +946,80 @@
         ]
       }
     },
+    "/api/simple-example/0x25/check-enum": {
+      "get": {
+        "summary": "Simple Example: Check enum values",
+        "description": "Check enum values used in api schema",
+        "parameters": [
+          {
+            "name": "enum_value",
+            "in": "query",
+            "required": true,
+            "description": "Enum value to validate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Id",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Track-Request-Ts",
+            "in": "header",
+            "required": false,
+            "description": "Track information: Request-Ts",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "X-Track-Caller",
+            "in": "header",
+            "required": true,
+            "description": "Track information: track.caller",
+            "schema": {
+              "type": "string",
+              "default": "test.caller"
+            }
+          },
+          {
+            "name": "X-Track-Session-Id",
+            "in": "header",
+            "required": true,
+            "description": "Track information: track.session_id",
+            "schema": {
+              "type": "string",
+              "default": "test.session_id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Enum value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CheckEnumResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "simple_example.0x25"
+        ]
+      }
+    },
     "/api/simple-example/0x25/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
@@ -2452,6 +2526,27 @@
           "user"
         ],
         "title": "SomethingParams",
+        "type": "object"
+      },
+      "CustomValue": {
+        "enum": [
+          "value1",
+          "value2",
+          "value3"
+        ],
+        "title": "CustomValue",
+        "type": "string"
+      },
+      "CheckEnumResponse": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/CustomValue"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "CheckEnumResponse",
         "type": "object"
       },
       "ItemsInfo": {

--- a/apps/examples/simple-example/config/app-config.json
+++ b/apps/examples/simple-example/config/app-config.json
@@ -105,6 +105,10 @@
       "type": "MULTIPART",
       "group": "g1"
     },
+    "check_enum": {
+      "type": "GET",
+      "auth" : ["Unsecured"]
+    },
     "service.something_generator": {
       "type": "SERVICE",
       "write_stream": {

--- a/apps/examples/simple-example/src/simple_example/check_enum.py
+++ b/apps/examples/simple-example/src/simple_example/check_enum.py
@@ -1,0 +1,58 @@
+"""
+Simple Example: Check enum values
+--------------------------------------------------------------------
+Check enum values used in api schema
+"""
+
+from enum import Enum
+from typing import Optional
+
+from hopeit.app.api import event_api
+from hopeit.app.context import EventContext
+from hopeit.app.logger import app_extra_logger
+from hopeit.dataobjects import dataobject, dataclass
+
+__steps__ = ["check_value"]
+
+
+class CustomValue(str, Enum):
+    VALUE1 = "value1"
+    VALUE2 = "value2"
+    VALUE3 = "value3"
+
+
+@dataobject
+@dataclass
+class CheckEnumResponse:
+    value: CustomValue
+
+
+
+
+__api__ = event_api(
+    summary="Simple Example: Check enum values",
+    query_args=[
+        (
+            "enum_value",
+            CustomValue,
+            "Enum value to validate"
+        )
+    ],
+    responses={
+        200: (list[CheckEnumResponse], "Enum value"),
+    },
+)
+
+logger, extra = app_extra_logger()
+
+
+async def check_value(payload: None, context: EventContext, enum_value: str) -> list[CheckEnumResponse]:
+    """
+    Check enum_value:str query arg is a valid CustomValue enum value and return it,
+    return None if it is not a valid value
+    """
+    try:
+        instance = CustomValue(enum_value)
+    except ValueError:
+        return []
+    return [CheckEnumResponse(value=instance)]

--- a/apps/examples/simple-example/src/simple_example/check_enum.py
+++ b/apps/examples/simple-example/src/simple_example/check_enum.py
@@ -5,7 +5,6 @@ Check enum values used in api schema
 """
 
 from enum import Enum
-from typing import Optional
 
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext
@@ -27,17 +26,9 @@ class CheckEnumResponse:
     value: CustomValue
 
 
-
-
 __api__ = event_api(
     summary="Simple Example: Check enum values",
-    query_args=[
-        (
-            "enum_value",
-            CustomValue,
-            "Enum value to validate"
-        )
-    ],
+    query_args=[("enum_value", CustomValue, "Enum value to validate")],
     responses={
         200: (list[CheckEnumResponse], "Enum value"),
     },
@@ -46,7 +37,9 @@ __api__ = event_api(
 logger, extra = app_extra_logger()
 
 
-async def check_value(payload: None, context: EventContext, enum_value: str) -> list[CheckEnumResponse]:
+async def check_value(
+    payload: None, context: EventContext, enum_value: str
+) -> list[CheckEnumResponse]:
     """
     Check enum_value:str query arg is a valid CustomValue enum value and return it,
     return None if it is not a valid value

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -1,6 +1,6 @@
-aiohttp>=3.9.0,<3.11
+aiohttp>=3.9.0,<4
 aiohttp-cors
-aiohttp-swagger3>=0.9.0
+aiohttp-swagger3>=0.10.0
 pydantic>=2.9.1,<3
 stringcase>=1.2.0
 lz4>=4.3.2

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -12,7 +12,6 @@ setup(
         "lz4>=4.3.2",
         "PyJWT[crypto]>=2.9.0",
         "deepdiff",
-        "typing-inspect",
         "multidict",
     ],
     extras_require={

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -17,9 +17,9 @@ setup(
     ],
     extras_require={
         "web": [
-            "aiohttp>=3.9.0,<3.11",
+            "aiohttp>=3.9.0,<4",
             "aiohttp-cors",
-            "aiohttp-swagger3>=0.9.0",
+            "aiohttp-swagger3>=0.10.0",
             "gunicorn",
         ],
         "cli": ["click"],

--- a/plugins/ops/apps-visualizer/test/integration/effective_events.json
+++ b/plugins/ops/apps-visualizer/test/integration/effective_events.json
@@ -270,6 +270,21 @@
       },
       "auth": []
     },
+    "check_enum": {
+      "type": "GET",
+      "plug_mode": "Standalone",
+      "route": null,
+      "impl": null,
+      "connections": [],
+      "read_stream": null,
+      "write_stream": null,
+      "auth": [
+        "Unsecured"
+      ],
+      "setting_keys": [],
+      "dataobjects": [],
+      "group": "DEFAULT"
+    }, 
     "service.something_generator": {
       "type": "SERVICE",
       "plug_mode": "Standalone",

--- a/plugins/ops/apps-visualizer/test/integration/events_graph_data_expanded.json
+++ b/plugins/ops/apps-visualizer/test/integration/events_graph_data_expanded.json
@@ -69,6 +69,20 @@
     },
     "classes": "EVENT"
   },
+  "simple_example.${APPS_ROUTE_VERSION}.check_enum": {
+    "classes": "EVENT",
+    "data": {
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncheck_enum",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.check_enum"
+    }
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET": {
+    "classes": "REQUEST",
+    "data": {
+      "content": "GET",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET"
+    }
+  },
   "simple_example.${APPS_ROUTE_VERSION}.query_something.GET": {
     "data": {
       "id": "simple_example.${APPS_ROUTE_VERSION}.query_something.GET",
@@ -477,6 +491,14 @@
       "id": "edge_simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
       "source": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently.POST",
       "target": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
+      "label": ""
+    }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.check_enum.GET": {
+    "data": {
+      "id": "edge_simple_example.${APPS_ROUTE_VERSION}.check_enum.GET",
+      "source": "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET",
+      "target": "simple_example.${APPS_ROUTE_VERSION}.check_enum",
       "label": ""
     }
   },

--- a/plugins/ops/apps-visualizer/test/integration/events_graph_data_standard.json
+++ b/plugins/ops/apps-visualizer/test/integration/events_graph_data_standard.json
@@ -76,6 +76,20 @@
       },
       "classes": "EVENT"
   },
+  "simple_example.${APPS_ROUTE_VERSION}.check_enum": {
+    "classes": "EVENT",
+    "data": {
+      "content": "simple_example.${APPS_ROUTE_VERSION}\ncheck_enum",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.check_enum"
+    }
+  },
+  "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET": {
+    "classes": "REQUEST",
+    "data": {
+      "content": "GET",
+      "id": "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET"
+    }
+  },
   "simple_example.${APPS_ROUTE_VERSION}.list_somethings_unsecured.GET": {
       "data": {
           "id": "simple_example.${APPS_ROUTE_VERSION}.list_somethings_unsecured.GET",
@@ -473,6 +487,14 @@
           "target": "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently",
           "label": ""
       }
+  },
+  "edge_simple_example.${APPS_ROUTE_VERSION}.check_enum.GET": {
+     "data": {
+        "id": "edge_simple_example.${APPS_ROUTE_VERSION}.check_enum.GET",
+        "label": "",
+        "source": "simple_example.${APPS_ROUTE_VERSION}.check_enum.GET",
+        "target": "simple_example.${APPS_ROUTE_VERSION}.check_enum"
+        }
   },
   "edge_simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn.POST": {
       "data": {

--- a/plugins/ops/config-manager/test/integration/runtime_simple_example.json
+++ b/plugins/ops/config-manager/test/integration/runtime_simple_example.json
@@ -1,46 +1,919 @@
 {
-  "apps": {
-      "simple_example.${APPS_ROUTE_VERSION}": {
-          "servers": [
-              {
-                  "host_name": "${HOST_NAME}",
-                  "pid": "${PID}",
-                  "url": "${URL}"
-              }
-          ],
-          "app_config": {
-              "app": {
-                  "name": "simple-example",
-                  "version": "${APPS_API_VERSION}"
-              },
-              "engine": {
-                  "import_modules": [
-                      "simple_example"
-                  ],
-                  "read_stream_timeout": 1000,
-                  "read_stream_interval": 1000,
-                  "default_stream_compression": "lz4",
-                  "default_stream_serialization": "json+base64",
-                  "track_headers": [
-                      "track.request_id",
-                      "track.request_ts",
-                      "track.caller",
-                      "track.session_id"
-                  ],
-                  "cors_origin": "*"
-              },
-              "app_connections": {},
-              "env": {
-                  "storage": {
-                      "base_path": "/tmp/hopeit/"
-                  },
-                  "upload_something": {
-                      "save_path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.upload_something.save_path/",
-                      "chunk_size": 16384
-                  }
-              },
-              "events": {
-                "setup_something": {
+    "apps": {
+        "simple_example.${APPS_ROUTE_VERSION}": {
+            "servers": [
+                {
+                    "host_name": "${HOST_NAME}",
+                    "pid": "${PID}",
+                    "url": "${URL}"
+                }
+            ],
+            "app_config": {
+                "app": {
+                    "name": "simple-example",
+                    "version": "${APPS_API_VERSION}"
+                },
+                "engine": {
+                    "import_modules": [
+                        "simple_example"
+                    ],
+                    "read_stream_timeout": 1000,
+                    "read_stream_interval": 1000,
+                    "default_stream_compression": "lz4",
+                    "default_stream_serialization": "json+base64",
+                    "track_headers": [
+                        "track.request_id",
+                        "track.request_ts",
+                        "track.caller",
+                        "track.session_id"
+                    ],
+                    "cors_origin": "*"
+                },
+                "app_connections": {},
+                "env": {
+                    "storage": {
+                        "base_path": "/tmp/hopeit/"
+                    },
+                    "upload_something": {
+                        "save_path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.upload_something.save_path/",
+                        "chunk_size": 16384
+                    }
+                },
+                "events": {
+                    "setup_something": {
+                        "type": "SETUP",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "list_somethings": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "check_enum": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [
+                            "Unsecured"
+                        ],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "list_somethings_unsecured": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "impl": "simple_example.list_somethings",
+                        "connections": [],
+                        "auth": [
+                            "Unsecured"
+                        ],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "query_something": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "route": "simple-example/${APPS_API_VERSION}/query_something",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "query_something_extended": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "route": "simple-example/${APPS_API_VERSION}/query_something",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "save_something": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "g2"
+                    },
+                    "download_something": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "download_something_streamed": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [
+                            "Unsecured"
+                        ],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "upload_something": {
+                        "type": "MULTIPART",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "g1"
+                    },
+                    "service.something_generator": {
+                        "type": "SERVICE",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "write_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "queues": [
+                                "AUTO"
+                            ],
+                            "queue_strategy": "DROP"
+                        },
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "streams.something_event": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "write_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "queues": [
+                                "high-prio"
+                            ],
+                            "queue_strategy": "DROP"
+                        },
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "streams.process_events": {
+                        "type": "STREAM",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "read_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+                            "queues": [
+                                "high-prio",
+                                "AUTO"
+                            ]
+                        },
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "collector.query_concurrently": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "collector.collect_spawn": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "write_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "queues": [
+                                "AUTO"
+                            ],
+                            "queue_strategy": "DROP"
+                        },
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "shuffle.spawn_event": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "write_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "queues": [
+                                "AUTO"
+                            ],
+                            "queue_strategy": "DROP"
+                        },
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "shuffle.parallelize_event": {
+                        "type": "POST",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "write_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "queues": [
+                                "AUTO"
+                            ],
+                            "queue_strategy": "DROP"
+                        },
+                        "auth": [],
+                        "setting_keys": [
+                            "fs_storage"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "storage.save_events_fs": {
+                        "type": "STREAM",
+                        "plug_mode": "Standalone",
+                        "impl": "hopeit.fs_storage.events.stream_batch_storage",
+                        "connections": [],
+                        "read_stream": {
+                            "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                            "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs",
+                            "queues": [
+                                "high-prio",
+                                "AUTO"
+                            ]
+                        },
+                        "auth": [],
+                        "setting_keys": [],
+                        "dataobjects": [
+                            "model.Something"
+                        ],
+                        "group": "DEFAULT"
+                    }
+                },
+                "server": {
+                    "streams": {
+                        "stream_manager": "hopeit.streams.NoStreamManager",
+                        "connection_str": "<<NoStreamManager>>",
+                        "delay_auto_start_seconds": 3
+                    },
+                    "logging": {
+                        "log_level": "DEBUG",
+                        "log_path": "logs/"
+                    },
+                    "auth": {
+                        "secrets_location": ".secrets/",
+                        "auth_passphrase": "",
+                        "enabled": false,
+                        "create_keys": false,
+                        "encryption_algorithm": "RS256",
+                        "default_auth_methods": [
+                            "Unsecured"
+                        ]
+                    },
+                    "api": {},
+                    "engine_version": "${APPS_API_VERSION}.2"
+                },
+                "plugins": [
+                    {
+                        "name": "basic-auth",
+                        "version": "${APPS_API_VERSION}"
+                    }
+                ],
+                "settings": {
+                    "streams.something_event": {
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ]
+                        }
+                    },
+                    "streams.process_events": {
+                        "logging": {
+                            "stream_fields": [
+                                "name",
+                                "msg_id",
+                                "consumer_group",
+                                "event_id",
+                                "event_ts",
+                                "submit_ts",
+                                "read_ts"
+                            ],
+                            "extra_fields": [
+                                "something_id"
+                            ]
+                        }
+                    },
+                    "collector.collect_spawn": {
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ]
+                        }
+                    },
+                    "shuffle.spawn_event": {
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ]
+                        }
+                    },
+                    "shuffle.parallelize_event": {
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ]
+                        }
+                    },
+                    "fs_storage": {
+                        "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                        "partition_dateformat": "%Y/%m/%d/%H/"
+                    },
+                    "storage.save_events_fs": {
+                        "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs.path",
+                        "partition_dateformat": "%Y/%m/%d/%H/",
+                        "flush_seconds": 60.0,
+                        "flush_max_size": 100
+                    },
+                    "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
+                        "target_max_len": 1000,
+                        "throttle_ms": 10,
+                        "batch_size": 5
+                    }
+                },
+                "effective_settings": {
+                    "setup_something": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "list_somethings": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "check_enum": {
+                        "response_timeout": 60,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "list_somethings_unsecured": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "query_something": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "query_something_extended": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "save_something": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "download_something": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "download_something_streamed": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "upload_something": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "service.something_generator": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    },
+                    "streams.something_event": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "logging": {
+                                    "extra_fields": [
+                                        "something_id"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "streams.process_events": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group",
+                                "stream.event_id",
+                                "stream.event_ts",
+                                "stream.submit_ts",
+                                "stream.read_ts"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "logging": {
+                                    "stream_fields": [
+                                        "name",
+                                        "msg_id",
+                                        "consumer_group",
+                                        "event_id",
+                                        "event_ts",
+                                        "submit_ts",
+                                        "read_ts"
+                                    ],
+                                    "extra_fields": [
+                                        "something_id"
+                                    ]
+                                }
+                            },
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "collector.query_concurrently": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "collector.collect_spawn": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "logging": {
+                                    "extra_fields": [
+                                        "something_id"
+                                    ]
+                                }
+                            },
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "shuffle.spawn_event": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "logging": {
+                                    "extra_fields": [
+                                        "something_id"
+                                    ]
+                                }
+                            },
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "shuffle.parallelize_event": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [
+                                "something_id"
+                            ],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "logging": {
+                                    "extra_fields": [
+                                        "something_id"
+                                    ]
+                                }
+                            },
+                            "fs_storage": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/"
+                            }
+                        }
+                    },
+                    "storage.save_events_fs": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 1000,
+                            "throttle_ms": 10,
+                            "step_delay": 0,
+                            "batch_size": 5,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "_": {
+                                "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs.path",
+                                "partition_dateformat": "%Y/%m/%d/%H/",
+                                "flush_seconds": 60.0,
+                                "flush_max_size": 100
+                            }
+                        }
+                    }
+                }
+            },
+            "effective_events": {
+                "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login": {
+                    "type": "GET",
+                    "plug_mode": "OnApp",
+                    "connections": [],
+                    "auth": [
+                        "Basic"
+                    ],
+                    "setting_keys": [
+                        "auth"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh": {
+                    "type": "GET",
+                    "plug_mode": "OnApp",
+                    "connections": [],
+                    "auth": [
+                        "Refresh"
+                    ],
+                    "setting_keys": [
+                        "auth"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout": {
+                    "type": "GET",
+                    "plug_mode": "OnApp",
+                    "connections": [],
+                    "auth": [
+                        "Refresh"
+                    ],
+                    "setting_keys": [
+                        "auth"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.setup_something": {
                     "type": "SETUP",
                     "plug_mode": "Standalone",
                     "connections": [],
@@ -49,1310 +922,484 @@
                     "dataobjects": [],
                     "group": "DEFAULT"
                 },
-                  "list_somethings": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "list_somethings_unsecured": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "impl": "simple_example.list_somethings",
-                      "connections": [],
-                      "auth": [
-                          "Unsecured"
-                      ],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "query_something": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "route": "simple-example/${APPS_API_VERSION}/query_something",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "query_something_extended": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "route": "simple-example/${APPS_API_VERSION}/query_something",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "save_something": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "g2"
-                  },
-                  "download_something": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "download_something_streamed": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [
-                          "Unsecured"
-                      ],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "upload_something": {
-                      "type": "MULTIPART",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "g1"
-                  },
-                  "service.something_generator": {
-                      "type": "SERVICE",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "write_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "queues": [
-                              "AUTO"
-                          ],
-                          "queue_strategy": "DROP"
-                      },
-                      "auth": [],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "streams.something_event": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "write_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "queues": [
-                              "high-prio"
-                          ],
-                          "queue_strategy": "DROP"
-                      },
-                      "auth": [],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "streams.process_events": {
-                      "type": "STREAM",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "read_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
-                          "queues": [
-                              "high-prio",
-                              "AUTO"
-                          ]
-                      },
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "collector.query_concurrently": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "collector.collect_spawn": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "write_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "queues": [
-                              "AUTO"
-                          ],
-                          "queue_strategy": "DROP"
-                      },
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "shuffle.spawn_event": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "write_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "queues": [
-                              "AUTO"
-                          ],
-                          "queue_strategy": "DROP"
-                      },
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "shuffle.parallelize_event": {
-                      "type": "POST",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "write_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "queues": [
-                              "AUTO"
-                          ],
-                          "queue_strategy": "DROP"
-                      },
-                      "auth": [],
-                      "setting_keys": [
-                          "fs_storage"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "storage.save_events_fs": {
-                      "type": "STREAM",
-                      "plug_mode": "Standalone",
-                      "impl": "hopeit.fs_storage.events.stream_batch_storage",
-                      "connections": [],
-                      "read_stream": {
-                          "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                          "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs",
-                          "queues": [
-                              "high-prio",
-                              "AUTO"
-                          ]
-                      },
-                      "auth": [],
-                      "setting_keys": [],
-                      "dataobjects": [
-                          "model.Something"
-                      ],
-                      "group": "DEFAULT"
-                  }
-              },
-              "server": {
-                  "streams": {
-                      "stream_manager": "hopeit.streams.NoStreamManager",
-                      "connection_str": "<<NoStreamManager>>",
-                      "delay_auto_start_seconds": 3
-                  },
-                  "logging": {
-                      "log_level": "DEBUG",
-                      "log_path": "logs/"
-                  },
-                  "auth": {
-                      "secrets_location": ".secrets/",
-                      "auth_passphrase": "",
-                      "enabled": false,
-                      "create_keys": false,
-                      "encryption_algorithm": "RS256",
-                      "default_auth_methods": [
-                          "Unsecured"
-                      ]
-                  },
-                  "api": {},
-                  "engine_version": "${APPS_API_VERSION}.2"
-              },
-              "plugins": [
-                  {
-                      "name": "basic-auth",
-                      "version": "${APPS_API_VERSION}"
-                  }
-              ],
-              "settings": {
-                  "streams.something_event": {
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ]
-                      }
-                  },
-                  "streams.process_events": {
-                      "logging": {
-                          "stream_fields": [
-                              "name",
-                              "msg_id",
-                              "consumer_group",
-                              "event_id",
-                              "event_ts",
-                              "submit_ts",
-                              "read_ts"
-                          ],
-                          "extra_fields": [
-                              "something_id"
-                          ]
-                      }
-                  },
-                  "collector.collect_spawn": {
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ]
-                      }
-                  },
-                  "shuffle.spawn_event": {
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ]
-                      }
-                  },
-                  "shuffle.parallelize_event": {
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ]
-                      }
-                  },
-                  "fs_storage": {
-                      "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                      "partition_dateformat": "%Y/%m/%d/%H/"
-                  },
-                  "storage.save_events_fs": {
-                      "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs.path",
-                      "partition_dateformat": "%Y/%m/%d/%H/",
-                      "flush_seconds": 60.0,
-                      "flush_max_size": 100
-                  },
-                  "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
-                      "target_max_len": 1000,
-                      "throttle_ms": 10,
-                      "batch_size": 5
-                  }
-              },
-              "effective_settings": {
-                 "setup_something": {
-                    "response_timeout": 60.0,
-                    "logging": {
-                        "extra_fields": [],
-                        "stream_fields": [
-                            "stream.name",
-                            "stream.msg_id",
-                            "stream.consumer_group"
+                "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.list_somethings_unsecured": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "impl": "simple_example.list_somethings",
+                    "connections": [],
+                    "auth": [
+                        "Unsecured"
+                    ],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.query_something": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "route": "simple-example/${APPS_API_VERSION}/query_something",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "route": "simple-example/${APPS_API_VERSION}/query_something",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.save_something": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "g2"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.download_something": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.download_something_streamed": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [
+                        "Unsecured"
+                    ],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
+                    "type": "MULTIPART",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "g1"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.check_enum": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "route": null,
+                    "impl": null,
+                    "connections": [],
+                    "read_stream": null,
+                    "write_stream": null,
+                    "auth": [
+                        "Unsecured"
+                    ],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
+                    "type": "SERVICE",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "write_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "queues": [
+                            "AUTO"
+                        ],
+                        "queue_strategy": "DROP"
+                    },
+                    "auth": [],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "write_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "queues": [
+                            "high-prio"
+                        ],
+                        "queue_strategy": "DROP"
+                    },
+                    "auth": [],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
+                    "type": "STREAM",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "read_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
+                        "queues": [
+                            "high-prio",
+                            "AUTO"
                         ]
                     },
-                    "stream": {
-                        "timeout": 60.0,
-                        "target_max_len": 0,
-                        "throttle_ms": 0,
-                        "step_delay": 0,
-                        "batch_size": 100,
-                        "compression": "lz4",
-                        "serialization": "json+base64"
-                    },
-                    "extras": {}
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
                 },
-                "list_somethings": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "list_somethings_unsecured": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "query_something": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "query_something_extended": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "save_something": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "download_something": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {}
-                  },
-                  "download_something_streamed": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {}
-                  },
-                  "upload_something": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {}
-                  },
-                  "service.something_generator": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {}
-                  },
-                  "streams.something_event": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "logging": {
-                                  "extra_fields": [
-                                      "something_id"
-                                  ]
-                              }
-                          }
-                      }
-                  },
-                  "streams.process_events": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group",
-                              "stream.event_id",
-                              "stream.event_ts",
-                              "stream.submit_ts",
-                              "stream.read_ts"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "logging": {
-                                  "stream_fields": [
-                                      "name",
-                                      "msg_id",
-                                      "consumer_group",
-                                      "event_id",
-                                      "event_ts",
-                                      "submit_ts",
-                                      "read_ts"
-                                  ],
-                                  "extra_fields": [
-                                      "something_id"
-                                  ]
-                              }
-                          },
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "collector.query_concurrently": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "collector.collect_spawn": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "logging": {
-                                  "extra_fields": [
-                                      "something_id"
-                                  ]
-                              }
-                          },
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "shuffle.spawn_event": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "logging": {
-                                  "extra_fields": [
-                                      "something_id"
-                                  ]
-                              }
-                          },
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "shuffle.parallelize_event": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [
-                              "something_id"
-                          ],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "logging": {
-                                  "extra_fields": [
-                                      "something_id"
-                                  ]
-                              }
-                          },
-                          "fs_storage": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.fs_storage.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/"
-                          }
-                      }
-                  },
-                  "storage.save_events_fs": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 1000,
-                          "throttle_ms": 10,
-                          "step_delay": 0,
-                          "batch_size": 5,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "_": {
-                              "path": "/tmp/hopeit//simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs.path",
-                              "partition_dateformat": "%Y/%m/%d/%H/",
-                              "flush_seconds": 60.0,
-                              "flush_max_size": 100
-                          }
-                      }
-                  }
-              }
-          },
-          "effective_events": {
-              "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.login": {
-                  "type": "GET",
-                  "plug_mode": "OnApp",
-                  "connections": [],
-                  "auth": [
-                      "Basic"
-                  ],
-                  "setting_keys": [
-                      "auth"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.refresh": {
-                  "type": "GET",
-                  "plug_mode": "OnApp",
-                  "connections": [],
-                  "auth": [
-                      "Refresh"
-                  ],
-                  "setting_keys": [
-                      "auth"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.basic_auth.${APPS_ROUTE_VERSION}.logout": {
-                  "type": "GET",
-                  "plug_mode": "OnApp",
-                  "connections": [],
-                  "auth": [
-                      "Refresh"
-                  ],
-                  "setting_keys": [
-                      "auth"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.setup_something": {
-                "type": "SETUP",
-                "plug_mode": "Standalone",
-                "connections": [],
-                "auth": [],
-                "setting_keys": [],
-                "dataobjects": [],
-                "group": "DEFAULT"
+                "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "write_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "queues": [
+                            "AUTO"
+                        ],
+                        "queue_strategy": "DROP"
+                    },
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "write_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "queues": [
+                            "AUTO"
+                        ],
+                        "queue_strategy": "DROP"
+                    },
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
+                    "type": "POST",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "write_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "queues": [
+                            "AUTO"
+                        ],
+                        "queue_strategy": "DROP"
+                    },
+                    "auth": [],
+                    "setting_keys": [
+                        "fs_storage"
+                    ],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                },
+                "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs": {
+                    "type": "STREAM",
+                    "plug_mode": "Standalone",
+                    "impl": "hopeit.fs_storage.events.stream_batch_storage",
+                    "connections": [],
+                    "read_stream": {
+                        "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
+                        "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs",
+                        "queues": [
+                            "high-prio",
+                            "AUTO"
+                        ]
+                    },
+                    "auth": [],
+                    "setting_keys": [],
+                    "dataobjects": [
+                        "model.Something"
+                    ],
+                    "group": "DEFAULT"
+                }
+            }
+        },
+        "basic_auth.${APPS_ROUTE_VERSION}": {
+            "servers": [
+                {
+                    "host_name": "${HOST_NAME}",
+                    "pid": "${PID}",
+                    "url": "${URL}"
+                }
+            ],
+            "app_config": {
+                "app": {
+                    "name": "basic-auth",
+                    "version": "${APPS_API_VERSION}"
+                },
+                "engine": {
+                    "import_modules": [
+                        "hopeit.basic_auth"
+                    ],
+                    "read_stream_timeout": 1000,
+                    "read_stream_interval": 1000,
+                    "default_stream_compression": "lz4",
+                    "default_stream_serialization": "json+base64",
+                    "track_headers": [
+                        "track.request_id",
+                        "track.request_ts"
+                    ],
+                    "cors_origin": "http://localhost:8020"
+                },
+                "app_connections": {},
+                "env": {},
+                "events": {
+                    "login": {
+                        "type": "GET",
+                        "plug_mode": "OnApp",
+                        "connections": [],
+                        "auth": [
+                            "Basic"
+                        ],
+                        "setting_keys": [
+                            "auth"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "refresh": {
+                        "type": "GET",
+                        "plug_mode": "OnApp",
+                        "connections": [],
+                        "auth": [
+                            "Refresh"
+                        ],
+                        "setting_keys": [
+                            "auth"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "logout": {
+                        "type": "GET",
+                        "plug_mode": "OnApp",
+                        "connections": [],
+                        "auth": [
+                            "Refresh"
+                        ],
+                        "setting_keys": [
+                            "auth"
+                        ],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    },
+                    "decode": {
+                        "type": "GET",
+                        "plug_mode": "Standalone",
+                        "connections": [],
+                        "auth": [
+                            "Bearer"
+                        ],
+                        "setting_keys": [],
+                        "dataobjects": [],
+                        "group": "DEFAULT"
+                    }
+                },
+                "server": {
+                    "streams": {
+                        "stream_manager": "hopeit.streams.NoStreamManager",
+                        "connection_str": "<<NoStreamManager>>",
+                        "delay_auto_start_seconds": 3,
+                        "initial_backoff_seconds": 1.0,
+                        "max_backoff_seconds": 60.0,
+                        "num_failures_open_circuit_breaker": 1
+                    },
+                    "logging": {
+                        "log_level": "DEBUG",
+                        "log_path": "logs/"
+                    },
+                    "auth": {
+                        "secrets_location": ".secrets/",
+                        "auth_passphrase": "",
+                        "enabled": false,
+                        "create_keys": false,
+                        "encryption_algorithm": "RS256",
+                        "default_auth_methods": [
+                            "Unsecured"
+                        ]
+                    },
+                    "api": {},
+                    "engine_version": "${APPS_API_VERSION}.2"
+                },
+                "plugins": [],
+                "settings": {
+                    "auth": {
+                        "access_token_expiration": 600,
+                        "refresh_token_expiration": 3600,
+                        "access_token_renew_window": 5
+                    }
+                },
+                "effective_settings": {
+                    "login": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "auth": {
+                                "access_token_expiration": 600,
+                                "refresh_token_expiration": 3600,
+                                "access_token_renew_window": 5
+                            }
+                        }
+                    },
+                    "refresh": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "auth": {
+                                "access_token_expiration": 600,
+                                "refresh_token_expiration": 3600,
+                                "access_token_renew_window": 5
+                            }
+                        }
+                    },
+                    "logout": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {
+                            "auth": {
+                                "access_token_expiration": 600,
+                                "refresh_token_expiration": 3600,
+                                "access_token_renew_window": 5
+                            }
+                        }
+                    },
+                    "decode": {
+                        "response_timeout": 60.0,
+                        "logging": {
+                            "extra_fields": [],
+                            "stream_fields": [
+                                "stream.name",
+                                "stream.msg_id",
+                                "stream.consumer_group"
+                            ]
+                        },
+                        "stream": {
+                            "timeout": 60.0,
+                            "target_max_len": 0,
+                            "throttle_ms": 0,
+                            "step_delay": 0,
+                            "batch_size": 100,
+                            "compression": "lz4",
+                            "serialization": "json+base64"
+                        },
+                        "extras": {}
+                    }
+                }
             },
-              "simple_example.${APPS_ROUTE_VERSION}.list_somethings": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.list_somethings_unsecured": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "impl": "simple_example.list_somethings",
-                  "connections": [],
-                  "auth": [
-                      "Unsecured"
-                  ],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.query_something": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "route": "simple-example/${APPS_API_VERSION}/query_something",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.query_something_extended": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "route": "simple-example/${APPS_API_VERSION}/query_something",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.save_something": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "g2"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.download_something": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.download_something_streamed": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [
-                      "Unsecured"
-                  ],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.upload_something": {
-                  "type": "MULTIPART",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "g1"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.service.something_generator": {
-                  "type": "SERVICE",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "write_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "queues": [
-                          "AUTO"
-                      ],
-                      "queue_strategy": "DROP"
-                  },
-                  "auth": [],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.streams.something_event": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "write_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "queues": [
-                          "high-prio"
-                      ],
-                      "queue_strategy": "DROP"
-                  },
-                  "auth": [],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.streams.process_events": {
-                  "type": "STREAM",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "read_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.streams.process_events",
-                      "queues": [
-                          "high-prio",
-                          "AUTO"
-                      ]
-                  },
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.collector.query_concurrently": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.collector.collect_spawn": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "write_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "queues": [
-                          "AUTO"
-                      ],
-                      "queue_strategy": "DROP"
-                  },
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.shuffle.spawn_event": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "write_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "queues": [
-                          "AUTO"
-                      ],
-                      "queue_strategy": "DROP"
-                  },
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.shuffle.parallelize_event": {
-                  "type": "POST",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "write_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "queues": [
-                          "AUTO"
-                      ],
-                      "queue_strategy": "DROP"
-                  },
-                  "auth": [],
-                  "setting_keys": [
-                      "fs_storage"
-                  ],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              },
-              "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs": {
-                  "type": "STREAM",
-                  "plug_mode": "Standalone",
-                  "impl": "hopeit.fs_storage.events.stream_batch_storage",
-                  "connections": [],
-                  "read_stream": {
-                      "name": "simple_example.${APPS_ROUTE_VERSION}.streams.something_event",
-                      "consumer_group": "simple_example.${APPS_ROUTE_VERSION}.storage.save_events_fs",
-                      "queues": [
-                          "high-prio",
-                          "AUTO"
-                      ]
-                  },
-                  "auth": [],
-                  "setting_keys": [],
-                  "dataobjects": [
-                      "model.Something"
-                  ],
-                  "group": "DEFAULT"
-              }
-          }
-      },
-      "basic_auth.${APPS_ROUTE_VERSION}": {
-          "servers": [
-              {
-                  "host_name": "${HOST_NAME}",
-                  "pid": "${PID}",
-                  "url": "${URL}"
-              }
-          ],
-          "app_config": {
-              "app": {
-                  "name": "basic-auth",
-                  "version": "${APPS_API_VERSION}"
-              },
-              "engine": {
-                  "import_modules": [
-                      "hopeit.basic_auth"
-                  ],
-                  "read_stream_timeout": 1000,
-                  "read_stream_interval": 1000,
-                  "default_stream_compression": "lz4",
-                  "default_stream_serialization": "json+base64",
-                  "track_headers": [
-                      "track.request_id",
-                      "track.request_ts"
-                  ],
-                  "cors_origin": "http://localhost:8020"
-              },
-              "app_connections": {},
-              "env": {},
-              "events": {
-                  "login": {
-                      "type": "GET",
-                      "plug_mode": "OnApp",
-                      "connections": [],
-                      "auth": [
-                          "Basic"
-                      ],
-                      "setting_keys": [
-                          "auth"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "refresh": {
-                      "type": "GET",
-                      "plug_mode": "OnApp",
-                      "connections": [],
-                      "auth": [
-                          "Refresh"
-                      ],
-                      "setting_keys": [
-                          "auth"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "logout": {
-                      "type": "GET",
-                      "plug_mode": "OnApp",
-                      "connections": [],
-                      "auth": [
-                          "Refresh"
-                      ],
-                      "setting_keys": [
-                          "auth"
-                      ],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  },
-                  "decode": {
-                      "type": "GET",
-                      "plug_mode": "Standalone",
-                      "connections": [],
-                      "auth": [
-                          "Bearer"
-                      ],
-                      "setting_keys": [],
-                      "dataobjects": [],
-                      "group": "DEFAULT"
-                  }
-              },
-              "server": {
-                  "streams": {
-                      "stream_manager": "hopeit.streams.NoStreamManager",
-                      "connection_str": "<<NoStreamManager>>",
-                      "delay_auto_start_seconds": 3,
-                      "initial_backoff_seconds": 1.0,
-                      "max_backoff_seconds": 60.0,
-                      "num_failures_open_circuit_breaker": 1
-                  },
-                  "logging": {
-                      "log_level": "DEBUG",
-                      "log_path": "logs/"
-                  },
-                  "auth": {
-                      "secrets_location": ".secrets/",
-                      "auth_passphrase": "",
-                      "enabled": false,
-                      "create_keys": false,
-                      "encryption_algorithm": "RS256",
-                      "default_auth_methods": [
-                          "Unsecured"
-                      ]
-                  },
-                  "api": {},
-                  "engine_version": "${APPS_API_VERSION}.2"
-              },
-              "plugins": [],
-              "settings": {
-                  "auth": {
-                      "access_token_expiration": 600,
-                      "refresh_token_expiration": 3600,
-                      "access_token_renew_window": 5
-                  }
-              },
-              "effective_settings": {
-                  "login": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "auth": {
-                              "access_token_expiration": 600,
-                              "refresh_token_expiration": 3600,
-                              "access_token_renew_window": 5
-                          }
-                      }
-                  },
-                  "refresh": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "auth": {
-                              "access_token_expiration": 600,
-                              "refresh_token_expiration": 3600,
-                              "access_token_renew_window": 5
-                          }
-                      }
-                  },
-                  "logout": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {
-                          "auth": {
-                              "access_token_expiration": 600,
-                              "refresh_token_expiration": 3600,
-                              "access_token_renew_window": 5
-                          }
-                      }
-                  },
-                  "decode": {
-                      "response_timeout": 60.0,
-                      "logging": {
-                          "extra_fields": [],
-                          "stream_fields": [
-                              "stream.name",
-                              "stream.msg_id",
-                              "stream.consumer_group"
-                          ]
-                      },
-                      "stream": {
-                          "timeout": 60.0,
-                          "target_max_len": 0,
-                          "throttle_ms": 0,
-                          "step_delay": 0,
-                          "batch_size": 100,
-                          "compression": "lz4",
-                          "serialization": "json+base64"
-                      },
-                      "extras": {}
-                  }
-              }
-          },
-          "effective_events": {
-              "basic_auth.${APPS_ROUTE_VERSION}.decode": {
-                  "type": "GET",
-                  "plug_mode": "Standalone",
-                  "connections": [],
-                  "auth": [
-                      "Bearer"
-                  ],
-                  "setting_keys": [],
-                  "dataobjects": [],
-                  "group": "DEFAULT"
-              }
-          }
-      }
-  },
-  "server_status": {
-      "${URL}": "ALIVE"
-  }
+            "effective_events": {
+                "basic_auth.${APPS_ROUTE_VERSION}.decode": {
+                    "type": "GET",
+                    "plug_mode": "Standalone",
+                    "connections": [],
+                    "auth": [
+                        "Bearer"
+                    ],
+                    "setting_keys": [],
+                    "dataobjects": [],
+                    "group": "DEFAULT"
+                }
+            }
+        }
+    },
+    "server_status": {
+        "${URL}": "ALIVE"
+    }
 }


### PR DESCRIPTION
chore:
- [x] Unpin aiohttp to support 3.11+ version after aiohttp-swagger 0.10.0 release
- [x] Added endpoint to check enum schemas in simple-example
 