### PR TITLE
fix(redis-streams): use blocking connection pool for redis-py 8 compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
             "module": "hopeit.server.web",
             "args": [
                 "--port=8040",
-                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/data/dataframes/config/plugin-config.json,apps/examples/dataframes-example/config/app-config.json",
+                "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/data/dataframes/config/plugin-config.json,apps/examples/dataframes-example/config/app-config.json",
                 "--api-file=apps/examples/dataframes-example/api/openapi.json",
                 "--start-streams",
             ],
@@ -70,7 +70,7 @@
             "module": "hopeit.server.job",
             "args": [
                 "--start-streams",
-                "--config-files=engine/config/dev-noauth.json,apps/examples/simple-example/config/job-config.json",
+                "--config-files=engine/config/dev-noauth.json,plugins/streams/redis/config/plugin-config.json,apps/examples/simple-example/config/job-config.json",
                 "--event-name=streams.something_event",
                 "--payload=@apps/examples/simple-example/resources/job-payload.json",
             ],
@@ -84,7 +84,7 @@
             "module": "hopeit.server.job",
             "args": [
                 "--start-streams",
-                "--config-files=engine/config/dev-noauth.json,apps/examples/simple-example/config/job-config.json",
+                "--config-files=engine/config/dev-noauth.json,plugins/streams/redis/config/plugin-config.json,apps/examples/simple-example/config/job-config.json",
                 "--event-name=streams.process_events",
                 "--max-events=2",
             ],
@@ -98,7 +98,7 @@
             "module": "hopeit.server.job",
             "args": [
                 "--start-streams",
-                "--config-files=engine/config/dev-noauth.json,apps/examples/simple-example/config/job-config.json",
+                "--config-files=engine/config/dev-noauth.json,plugins/streams/redis/config/plugin-config.json,apps/examples/simple-example/config/job-config.json",
                 "--event-name=shuffle.spawn_event",
                 "--payload=@apps/examples/simple-example/resources/spawn-payload.json",
                 "--track={\"something_id\":\"abc123\"}"
@@ -117,7 +117,7 @@
             "args": [
                 "--port=8098",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json",
+                "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/apps-visualizer/config/plugin-config.json",
                 "--api-file=plugins/ops/apps-visualizer/api/openapi.json"
             ],
             "cwd": "${workspaceFolder}",
@@ -131,7 +131,7 @@
             "args": [
                 "--port=8099",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/log-streamer/config/plugin-config.json"
+                "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/log-streamer/config/plugin-config.json"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,10 @@
                 "--api-file=apps/examples/dataframes-example/api/openapi.json",
                 "--start-streams",
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },
@@ -74,6 +78,10 @@
                 "--event-name=streams.something_event",
                 "--payload=@apps/examples/simple-example/resources/job-payload.json",
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },
@@ -88,6 +96,10 @@
                 "--event-name=streams.process_events",
                 "--max-events=2",
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },
@@ -103,6 +115,10 @@
                 "--payload=@apps/examples/simple-example/resources/spawn-payload.json",
                 "--track={\"something_id\":\"abc123\"}"
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },
@@ -112,7 +128,9 @@
             "request": "launch",
             "module": "hopeit.server.web",
             "env": {
-                "HOPEIT_APPS_VISUALIZER_HOSTS": "http://localhost:8020,http://localhost:8021,http://localhost:8030,http://localhost:8098,http://localhost:8099"
+                "HOPEIT_APPS_VISUALIZER_HOSTS": "http://localhost:8020,http://localhost:8021,http://localhost:8030,http://localhost:8098,http://localhost:8099",
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
             },
             "args": [
                 "--port=8098",
@@ -133,6 +151,10 @@
                 "--start-streams",
                 "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,plugins/ops/log-streamer/config/plugin-config.json"
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,10 @@
                 "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
                 "--api-file=apps/examples/simple-example/api/openapi.json"
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "args": [
                 "--port=8020",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
+                "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
                 "--api-file=apps/examples/simple-example/api/openapi.json"
             ],
             "cwd": "${workspaceFolder}",
@@ -23,9 +23,13 @@
             "args": [
                 "--port=8020",
                 "--start-streams",
-                "--config-files=engine/config/dev-local.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
+                "--config-files=engine/config/dev-local.json,plugins/streams/redis/config/plugin-config.json,plugins/auth/basic-auth/config/plugin-config.json,plugins/ops/config-manager/config/plugin-config.json,apps/examples/simple-example/config/app-config.json",
                 "--api-auto=0.18;Simple Example;Simple Example OpenAPI specs"
             ],
+            "env": {
+                "REDIS_USERNAME": "",
+                "REDIS_PASSWORD": "",
+            },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ format:
 lint-engine:
 	uv run --no-sync ruff format --check engine/src/ engine/test/
 	uv run --no-sync ruff check engine/src/ engine/test/
-	MYPYPATH=engine/src/ uv run --no-sync mypy --namespace-packages -p hopeit
-	MYPYPATH=engine/src:engine/test/ uv run --no-sync mypy --namespace-packages engine/test/unit/
-	MYPYPATH=engine/src:engine/test/ uv run --no-sync mypy --namespace-packages engine/test/integration/
+	PYTHONPATH=engine/src MYPYPATH=engine/src/ uv run --no-sync mypy --namespace-packages -p hopeit
+	PYTHONPATH=engine/src:engine/test MYPYPATH=engine/src:engine/test/ uv run --no-sync mypy --namespace-packages engine/test/unit/
+	PYTHONPATH=engine/src:engine/test MYPYPATH=engine/src:engine/test/ uv run --no-sync mypy --namespace-packages engine/test/integration/
 
 lint-plugin:
 	uv run --no-sync ruff format --check $(PLUGINFOLDER)/src/ $(PLUGINFOLDER)/test/

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.29",
+    "version": "0.30",
     "title": "Client Example",
     "description": "Client Example"
   },
   "paths": {
-    "/api/config-manager/0x29/runtime-apps-config": {
+    "/api/config-manager/0x30/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/config-manager/0x29/cluster-apps-config": {
+    "/api/config-manager/0x30/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,11 +122,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/client-example/0x29/call-unsecured": {
+    "/api/client-example/0x30/call-unsecured": {
       "get": {
         "summary": "Client Example: Call Unsecured",
         "description": "List all available Something objects connecting to simple-example app",
@@ -196,11 +196,11 @@
           }
         },
         "tags": [
-          "client_example.0x29"
+          "client_example.0x30"
         ]
       }
     },
-    "/api/client-example/0x29/count-and-save": {
+    "/api/client-example/0x30/count-and-save": {
       "get": {
         "summary": "Client Example: Count Objects and Save new one",
         "description": "Count all available Something objects connecting to simple-example app",
@@ -267,7 +267,7 @@
           }
         },
         "tags": [
-          "client_example.0x29"
+          "client_example.0x30"
         ],
         "security": [
           {
@@ -276,7 +276,7 @@
         ]
       }
     },
-    "/api/client-example/0x29/handle-responses": {
+    "/api/client-example/0x30/handle-responses": {
       "get": {
         "summary": "Client Example: Handle Responses",
         "description": "Non default responses and UnhandledResponse exception\n\nTo manage different types of responses from the same endpoint we can use the `responses` parameter where we list the\nhttp response status codes expected and the corresponding data type for each one. In this example `app_call` expect\nand handle, 200 and 404 responses.\n\nAlso in the code you can see how to handle an expection of type `UnhandledResponse` and log as warining.",
@@ -361,7 +361,7 @@
           }
         },
         "tags": [
-          "client_example.0x29"
+          "client_example.0x30"
         ],
         "security": [
           {
@@ -892,7 +892,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.29.0",
+            "default": "0.30.0",
             "title": "Engine Version",
             "type": "string"
           }
@@ -942,7 +942,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -953,18 +953,6 @@
             "default": "<<NoStreamManager>>",
             "title": "Connection Str",
             "type": "string"
-          },
-          "username": {
-            "format": "password",
-            "title": "Username",
-            "type": "string",
-            "writeOnly": true
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string",
-            "writeOnly": true
           },
           "delay_auto_start_seconds": {
             "default": 3,
@@ -984,21 +972,6 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
-            "type": "integer"
-          },
-          "max_connections": {
-            "default": 100,
-            "title": "Max Connections",
-            "type": "integer"
-          },
-          "blocking_pool_timeout": {
-            "default": 20.0,
-            "title": "Blocking Pool Timeout",
-            "type": "number"
-          },
-          "protocol": {
-            "default": 2,
-            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/apps/examples/client-example/api/openapi.json
+++ b/apps/examples/client-example/api/openapi.json
@@ -942,7 +942,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -984,6 +984,21 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
+            "type": "integer"
+          },
+          "max_connections": {
+            "default": 100,
+            "title": "Max Connections",
+            "type": "integer"
+          },
+          "blocking_pool_timeout": {
+            "default": 20.0,
+            "title": "Blocking Pool Timeout",
+            "type": "number"
+          },
+          "protocol": {
+            "default": 2,
+            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/apps/examples/client-example/pyproject.toml
+++ b/apps/examples/client-example/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "client_example"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "hopeit.engine Client Example App"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "simple-example>=0.29.0",
-    "hopeit.basic-auth>=0.29.0",
-    "hopeit.apps-client>=0.29.0",
+    "hopeit.engine>=0.30.0",
+    "simple-example>=0.30.0",
+    "hopeit.basic-auth>=0.30.0",
+    "hopeit.apps-client>=0.30.0",
 ]
 
 license = "Apache-2.0"

--- a/apps/examples/dataframes-example/api/openapi.json
+++ b/apps/examples/dataframes-example/api/openapi.json
@@ -1527,7 +1527,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -1569,6 +1569,21 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
+            "type": "integer"
+          },
+          "max_connections": {
+            "default": 100,
+            "title": "Max Connections",
+            "type": "integer"
+          },
+          "blocking_pool_timeout": {
+            "default": 20.0,
+            "title": "Blocking Pool Timeout",
+            "type": "number"
+          },
+          "protocol": {
+            "default": 2,
+            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/apps/examples/dataframes-example/api/openapi.json
+++ b/apps/examples/dataframes-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.29",
+    "version": "0.30",
     "title": "Dataframes Example",
     "description": "Dataframes Example"
   },
   "paths": {
-    "/api/basic-auth/0x29/decode": {
+    "/api/basic-auth/0x30/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.0x29"
+          "basic_auth.0x30"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/config-manager/0x29/runtime-apps-config": {
+    "/api/config-manager/0x30/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -109,11 +109,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/config-manager/0x29/cluster-apps-config": {
+    "/api/config-manager/0x30/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -169,11 +169,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/dataframes/0x29/setup/register-database": {
+    "/api/dataframes/0x30/setup/register-database": {
       "post": {
         "summary": "Register Database",
         "description": "Register Database",
@@ -222,7 +222,7 @@
           }
         },
         "tags": [
-          "dataframes.0x29"
+          "dataframes.0x30"
         ],
         "security": [
           {
@@ -231,7 +231,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/prepare-data": {
+    "/api/dataframes-example/0x30/prepare-data": {
       "get": {
         "summary": "Prepare Data",
         "description": "Prepare Data",
@@ -279,7 +279,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -288,7 +288,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/train-model": {
+    "/api/dataframes-example/0x30/train-model": {
       "post": {
         "summary": "Training Pipeline",
         "description": "Training Pipeline",
@@ -347,7 +347,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -356,7 +356,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/predict": {
+    "/api/dataframes-example/0x30/predict": {
       "post": {
         "summary": "Predict",
         "description": "Predict",
@@ -424,7 +424,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -433,7 +433,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/predict-offline": {
+    "/api/dataframes-example/0x30/predict-offline": {
       "post": {
         "summary": "Predict Offline",
         "description": "Predict Offline",
@@ -501,7 +501,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -510,7 +510,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/offline-prediction-results": {
+    "/api/dataframes-example/0x30/offline-prediction-results": {
       "post": {
         "summary": "Offline Prediction Results",
         "description": "Offline Prediction Results",
@@ -572,7 +572,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -581,7 +581,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/experiment": {
+    "/api/dataframes-example/0x30/experiment": {
       "get": {
         "summary": "Experiment",
         "description": "Experiment",
@@ -666,7 +666,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -675,7 +675,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/basic-auth/0x29/login": {
+    "/api/dataframes-example/0x30/basic-auth/0x30/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -733,7 +733,7 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
@@ -742,7 +742,7 @@
         ]
       }
     },
-    "/api/dataframes-example/0x29/basic-auth/0x29/refresh": {
+    "/api/dataframes-example/0x30/basic-auth/0x30/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -800,16 +800,16 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
-            "dataframes_example.0x29.refresh": []
+            "dataframes_example.0x30.refresh": []
           }
         ]
       }
     },
-    "/api/dataframes-example/0x29/basic-auth/0x29/logout": {
+    "/api/dataframes-example/0x30/basic-auth/0x30/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -876,11 +876,11 @@
           }
         },
         "tags": [
-          "dataframes_example.0x29"
+          "dataframes_example.0x30"
         ],
         "security": [
           {
-            "dataframes_example.0x29.refresh": []
+            "dataframes_example.0x30.refresh": []
           }
         ]
       }
@@ -1477,7 +1477,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.29.0",
+            "default": "0.30.0",
             "title": "Engine Version",
             "type": "string"
           }
@@ -1527,7 +1527,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -1538,18 +1538,6 @@
             "default": "<<NoStreamManager>>",
             "title": "Connection Str",
             "type": "string"
-          },
-          "username": {
-            "format": "password",
-            "title": "Username",
-            "type": "string",
-            "writeOnly": true
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string",
-            "writeOnly": true
           },
           "delay_auto_start_seconds": {
             "default": 3,
@@ -1569,21 +1557,6 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
-            "type": "integer"
-          },
-          "max_connections": {
-            "default": 100,
-            "title": "Max Connections",
-            "type": "integer"
-          },
-          "blocking_pool_timeout": {
-            "default": 20.0,
-            "title": "Blocking Pool Timeout",
-            "type": "number"
-          },
-          "protocol": {
-            "default": 2,
-            "title": "Protocol",
             "type": "integer"
           }
         },
@@ -2155,10 +2128,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "dataframes_example.0x29.refresh": {
+      "dataframes_example.0x30.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "dataframes_example.0x29.refresh"
+        "name": "dataframes_example.0x30.refresh"
       }
     }
   },

--- a/apps/examples/dataframes-example/pyproject.toml
+++ b/apps/examples/dataframes-example/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "dataframes_example"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "hopeit.engine dataframes example app"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "hopeit.dataframes[polars]>=0.29.0",
+    "hopeit.engine>=0.30.0",
+    "hopeit.dataframes[polars]>=0.30.0",
 ]
 
 license = "Apache-2.0"

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.29",
+    "version": "0.30",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/basic-auth/0x29/decode": {
+    "/api/basic-auth/0x30/decode": {
       "get": {
         "summary": "Basic Auth: Decode",
         "description": "Returns decoded auth info",
@@ -44,7 +44,7 @@
           }
         },
         "tags": [
-          "basic_auth.0x29"
+          "basic_auth.0x30"
         ],
         "security": [
           {
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/config-manager/0x29/runtime-apps-config": {
+    "/api/config-manager/0x30/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -109,11 +109,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/config-manager/0x29/cluster-apps-config": {
+    "/api/config-manager/0x30/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -169,11 +169,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/simple-example/0x29/list-somethings": {
+    "/api/simple-example/0x30/list-somethings": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -243,7 +243,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -252,7 +252,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/list-somethings-unsecured": {
+    "/api/simple-example/0x30/list-somethings-unsecured": {
       "get": {
         "summary": "Simple Example: List Objects",
         "description": "Lists all available Something objects",
@@ -322,11 +322,11 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ]
       }
     },
-    "/api/simple-example/0x29/query-something": {
+    "/api/simple-example/0x30/query-something": {
       "get": {
         "summary": "Simple Example: Query Something",
         "description": "Loads Something from disk",
@@ -412,7 +412,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -516,7 +516,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -525,7 +525,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/save-something": {
+    "/api/simple-example/0x30/save-something": {
       "post": {
         "summary": "Simple Example: Save Something",
         "description": "Creates and saves Something",
@@ -622,7 +622,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -631,7 +631,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/download-something": {
+    "/api/simple-example/0x30/download-something": {
       "get": {
         "summary": "Simple Example: Download Something",
         "description": "Download image file. The PostprocessHook return the requested file as stream.",
@@ -718,7 +718,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -727,7 +727,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/download-something-streamed": {
+    "/api/simple-example/0x30/download-something-streamed": {
       "get": {
         "summary": "Simple Example: Download Something Streamed",
         "description": "Download streamd created content as file.\nThe PostprocessHook return the requested resource as stream using `prepare_stream_response`.",
@@ -795,11 +795,11 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ]
       }
     },
-    "/api/simple-example/0x29/upload-something": {
+    "/api/simple-example/0x30/upload-something": {
       "post": {
         "summary": "Simple Example: Multipart Upload files",
         "description": "Upload files using Multipart form request",
@@ -937,7 +937,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -946,7 +946,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/check-enum": {
+    "/api/simple-example/0x30/check-enum": {
       "get": {
         "summary": "Simple Example: Check enum values",
         "description": "Check enum values used in api schema",
@@ -1016,11 +1016,11 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ]
       }
     },
-    "/api/simple-example/0x29/streams/something-event": {
+    "/api/simple-example/0x30/streams/something-event": {
       "post": {
         "summary": "Simple Example: Something Event",
         "description": "Submits a Something object to a stream to be processed asynchronously by process-events app event",
@@ -1089,7 +1089,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1098,7 +1098,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/collector/query-concurrently": {
+    "/api/simple-example/0x30/collector/query-concurrently": {
       "post": {
         "summary": "Simple Example: Query Concurrently",
         "description": "Loads 2 Something objects concurrently from disk and combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)",
@@ -1170,7 +1170,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1179,7 +1179,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/collector/collect-spawn": {
+    "/api/simple-example/0x30/collector/collect-spawn": {
       "post": {
         "summary": "Simple Example: Collect and Spawn",
         "description": "Loads 2 Something objects concurrently from disk, combine the results\nusing `collector` steps constructor (instantiating an `AsyncCollector`)\nthen spawn the items found individually into a stream",
@@ -1257,7 +1257,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1266,7 +1266,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/shuffle/spawn-event": {
+    "/api/simple-example/0x30/shuffle/spawn-event": {
       "post": {
         "summary": "Simple Example: Spawn Event",
         "description": "This example will spawn 3 data events, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available",
@@ -1344,7 +1344,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1353,7 +1353,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/shuffle/parallelize-event": {
+    "/api/simple-example/0x30/shuffle/parallelize-event": {
       "post": {
         "summary": "Simple Example: Parallelize Event",
         "description": "This example will spawn 2 copies of payload data, those are going to be send to a stream using SHUFFLE\nand processed in asynchronously / in parallel if multiple nodes are available,\nthen submitted to other stream to be updated and saved",
@@ -1431,7 +1431,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1440,7 +1440,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/basic-auth/0x29/login": {
+    "/api/simple-example/0x30/basic-auth/0x30/login": {
       "get": {
         "summary": "Basic Auth: Login",
         "description": "Handles users login using basic-auth\nand generate access tokens for external services invoking apps\nplugged in with basic-auth plugin.",
@@ -1508,7 +1508,7 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
@@ -1517,7 +1517,7 @@
         ]
       }
     },
-    "/api/simple-example/0x29/basic-auth/0x29/refresh": {
+    "/api/simple-example/0x30/basic-auth/0x30/refresh": {
       "get": {
         "summary": "Basic Auth: Refresh",
         "description": "This event can be used for obtain new access token and update refresh token (http cookie),\nwith no need to re-login the user if there is a valid refresh token active.",
@@ -1585,16 +1585,16 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
-            "simple_example.0x29.refresh": []
+            "simple_example.0x30.refresh": []
           }
         ]
       }
     },
-    "/api/simple-example/0x29/basic-auth/0x29/logout": {
+    "/api/simple-example/0x30/basic-auth/0x30/logout": {
       "get": {
         "summary": "Basic Auth: Logout",
         "description": "Invalidates previous refresh cookies.",
@@ -1671,11 +1671,11 @@
           }
         },
         "tags": [
-          "simple_example.0x29"
+          "simple_example.0x30"
         ],
         "security": [
           {
-            "simple_example.0x29.refresh": []
+            "simple_example.0x30.refresh": []
           }
         ]
       }
@@ -2272,7 +2272,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.29.0",
+            "default": "0.30.0",
             "title": "Engine Version",
             "type": "string"
           }
@@ -2322,7 +2322,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -2333,18 +2333,6 @@
             "default": "<<NoStreamManager>>",
             "title": "Connection Str",
             "type": "string"
-          },
-          "username": {
-            "format": "password",
-            "title": "Username",
-            "type": "string",
-            "writeOnly": true
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string",
-            "writeOnly": true
           },
           "delay_auto_start_seconds": {
             "default": 3,
@@ -2364,21 +2352,6 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
-            "type": "integer"
-          },
-          "max_connections": {
-            "default": 100,
-            "title": "Max Connections",
-            "type": "integer"
-          },
-          "blocking_pool_timeout": {
-            "default": 20.0,
-            "title": "Blocking Pool Timeout",
-            "type": "number"
-          },
-          "protocol": {
-            "default": 2,
-            "title": "Protocol",
             "type": "integer"
           }
         },
@@ -2605,10 +2578,10 @@
         "type": "http",
         "scheme": "bearer"
       },
-      "simple_example.0x29.refresh": {
+      "simple_example.0x30.refresh": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "simple_example.0x29.refresh"
+        "name": "simple_example.0x30.refresh"
       }
     }
   },

--- a/apps/examples/simple-example/api/openapi.json
+++ b/apps/examples/simple-example/api/openapi.json
@@ -2322,7 +2322,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -2364,6 +2364,21 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
+            "type": "integer"
+          },
+          "max_connections": {
+            "default": 100,
+            "title": "Max Connections",
+            "type": "integer"
+          },
+          "blocking_pool_timeout": {
+            "default": 20.0,
+            "title": "Blocking Pool Timeout",
+            "type": "number"
+          },
+          "protocol": {
+            "default": 2,
+            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/apps/examples/simple-example/pyproject.toml
+++ b/apps/examples/simple-example/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "simple_example"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "hopeit.engine Example App"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "hopeit.basic-auth>=0.29.0",
+    "hopeit.engine>=0.30.0",
+    "hopeit.basic-auth>=0.30.0",
 ]
 
 license = "Apache-2.0"

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,41 @@
 Release Notes
 =============
 
+Version 0.30.0
+______________
+
+- Engine:
+
+  - ``hopeit_job`` now executes standalone SETUP events in configuration-file order,
+    before starting dependent applications.
+
+- Plugins:
+
+  - redis-streams:
+
+    - Redis Stream connections now use configurable blocking connection pools.
+      Authentication, maximum connections, pool timeout, and Redis protocol version
+      are configured by the plugin's ``redis_auth`` and ``redis_pool`` settings.
+
+BREAKING CHANGES
+^^^^^^^^^^^^^^^^
+
+- Plugins:
+
+  - redis-streams:
+
+    - Redis Streams must now be initialized by its ``setup_redis_pool`` SETUP event.
+      Every server or job command that uses Redis Streams must include the Redis Streams
+      ``plugin-config.json`` after the server config and before any dependent application
+      configs::
+
+        --config-files=server-config.json,plugins/streams/redis/config/plugin-config.json,app-config.json
+
+    - ``username`` and ``password`` were removed from the engine ``streams`` configuration.
+      They must now be provided through the plugin's ``redis_auth`` settings. The supplied
+      plugin config reads them from ``REDIS_USERNAME`` and ``REDIS_PASSWORD``; both variables
+      must be defined, using empty values when Redis authentication is disabled.
+
 Version 0.29.0
 ______________
 

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -497,7 +497,7 @@
       "type": "string"
     },
     "StreamsConfig": {
-      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
       "properties": {
         "stream_manager": {
           "default": "hopeit.streams.NoStreamManager",
@@ -539,6 +539,21 @@
         "num_failures_open_circuit_breaker": {
           "default": 1,
           "title": "Num Failures Open Circuit Breaker",
+          "type": "integer"
+        },
+        "max_connections": {
+          "default": 100,
+          "title": "Max Connections",
+          "type": "integer"
+        },
+        "blocking_pool_timeout": {
+          "default": 20.0,
+          "title": "Blocking Pool Timeout",
+          "type": "number"
+        },
+        "protocol": {
+          "default": 2,
+          "title": "Protocol",
           "type": "integer"
         }
       },

--- a/engine/config/schemas/app-config-schema-draftv6.json
+++ b/engine/config/schemas/app-config-schema-draftv6.json
@@ -479,7 +479,7 @@
           "$ref": "#/$defs/APIConfig"
         },
         "engine_version": {
-          "default": "0.29.0",
+          "default": "0.30.0",
           "title": "Engine Version",
           "type": "string"
         }
@@ -497,7 +497,7 @@
       "type": "string"
     },
     "StreamsConfig": {
-      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
       "properties": {
         "stream_manager": {
           "default": "hopeit.streams.NoStreamManager",
@@ -508,18 +508,6 @@
           "default": "<<NoStreamManager>>",
           "title": "Connection Str",
           "type": "string"
-        },
-        "username": {
-          "format": "password",
-          "title": "Username",
-          "type": "string",
-          "writeOnly": true
-        },
-        "password": {
-          "format": "password",
-          "title": "Password",
-          "type": "string",
-          "writeOnly": true
         },
         "delay_auto_start_seconds": {
           "default": 3,
@@ -539,21 +527,6 @@
         "num_failures_open_circuit_breaker": {
           "default": 1,
           "title": "Num Failures Open Circuit Breaker",
-          "type": "integer"
-        },
-        "max_connections": {
-          "default": 100,
-          "title": "Max Connections",
-          "type": "integer"
-        },
-        "blocking_pool_timeout": {
-          "default": 20.0,
-          "title": "Blocking Pool Timeout",
-          "type": "number"
-        },
-        "protocol": {
-          "default": 2,
-          "title": "Protocol",
           "type": "integer"
         }
       },

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -105,7 +105,7 @@
       "type": "object"
     },
     "StreamsConfig": {
-      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
       "properties": {
         "stream_manager": {
           "default": "hopeit.streams.NoStreamManager",
@@ -147,6 +147,21 @@
         "num_failures_open_circuit_breaker": {
           "default": 1,
           "title": "Num Failures Open Circuit Breaker",
+          "type": "integer"
+        },
+        "max_connections": {
+          "default": 100,
+          "title": "Max Connections",
+          "type": "integer"
+        },
+        "blocking_pool_timeout": {
+          "default": 20.0,
+          "title": "Blocking Pool Timeout",
+          "type": "number"
+        },
+        "protocol": {
+          "default": 2,
+          "title": "Protocol",
           "type": "integer"
         }
       },

--- a/engine/config/schemas/server-config-schema-draftv6.json
+++ b/engine/config/schemas/server-config-schema-draftv6.json
@@ -105,7 +105,7 @@
       "type": "object"
     },
     "StreamsConfig": {
-      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+      "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
       "properties": {
         "stream_manager": {
           "default": "hopeit.streams.NoStreamManager",
@@ -116,18 +116,6 @@
           "default": "<<NoStreamManager>>",
           "title": "Connection Str",
           "type": "string"
-        },
-        "username": {
-          "format": "password",
-          "title": "Username",
-          "type": "string",
-          "writeOnly": true
-        },
-        "password": {
-          "format": "password",
-          "title": "Password",
-          "type": "string",
-          "writeOnly": true
         },
         "delay_auto_start_seconds": {
           "default": 3,
@@ -147,21 +135,6 @@
         "num_failures_open_circuit_breaker": {
           "default": 1,
           "title": "Num Failures Open Circuit Breaker",
-          "type": "integer"
-        },
-        "max_connections": {
-          "default": 100,
-          "title": "Max Connections",
-          "type": "integer"
-        },
-        "blocking_pool_timeout": {
-          "default": 20.0,
-          "title": "Blocking Pool Timeout",
-          "type": "number"
-        },
-        "protocol": {
-          "default": 2,
-          "title": "Protocol",
           "type": "integer"
         }
       },
@@ -184,7 +157,7 @@
       "$ref": "#/$defs/APIConfig"
     },
     "engine_version": {
-      "default": "0.29.0",
+      "default": "0.30.0",
       "title": "Engine Version",
       "type": "string"
     }

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -5,17 +5,17 @@ description = "Hopeit Engine: Microservices with Streams"
 dynamic = ["version", "readme"]
 
 dependencies = [
-    "pydantic>=2.12.5,<3",
+    "pydantic>=2.13.4,<3",
     "lz4>=4.4.5",
-    "PyJWT[crypto]>=2.10.1",
-    "deepdiff>=8.6.1",
-    "multidict>=6.7.0",
-    "aiohttp>=3.11.12,<4",
+    "PyJWT[crypto]>=2.13.0",
+    "deepdiff>=9.1.0",
+    "multidict>=6.7.1",
+    "aiohttp>=3.14.1,<4",
     "aiohttp-cors>=0.8.1",
     "aiohttp-swagger3>=0.10.0",
-    "gunicorn>=23.0.0",
-    "click>=8.3.1",
-    "uvloop>=0.22; platform_system != 'Windows'"
+    "gunicorn>=26.0.0",
+    "click>=8.4.1",
+    "uvloop>=0.22.1; platform_system != 'Windows'"
 ]
 
 license = "Apache-2.0"
@@ -54,14 +54,14 @@ include-package-data = true
 [project.optional-dependencies]
 web = []
 cli = []
-redis-streams = ["hopeit.redis-streams==0.29.0"]
-redis-storage = ["hopeit.redis-storage==0.29.0"]
-fs-storage = ["hopeit.fs-storage==0.29.0"]
-config-manager = ["hopeit.config-manager==0.29.0"]
-log-streamer = ["hopeit.log-streamer==0.29.0"]
-apps-visualizer = ["hopeit.apps-visualizer==0.29.0"]
-apps-client = ["hopeit.apps-client==0.29.0"]
-dataframes = ["hopeit.dataframes==0.29.0"]
+redis-streams = ["hopeit.redis-streams==0.30.0"]
+redis-storage = ["hopeit.redis-storage==0.30.0"]
+fs-storage = ["hopeit.fs-storage==0.30.0"]
+config-manager = ["hopeit.config-manager==0.30.0"]
+log-streamer = ["hopeit.log-streamer==0.30.0"]
+apps-visualizer = ["hopeit.apps-visualizer==0.30.0"]
+apps-client = ["hopeit.apps-client==0.30.0"]
+dataframes = ["hopeit.dataframes==0.30.0"]
 
 [project.scripts]
 hopeit_server = "hopeit.cli.server:server"

--- a/engine/src/hopeit/app/client.py
+++ b/engine/src/hopeit/app/client.py
@@ -15,7 +15,7 @@ from hopeit.server.logger import engine_logger, extra_logger
 logger = engine_logger()
 extra = extra_logger()
 
-_registered_clients = {}
+_registered_clients: Dict[str, Dict[str, "Client"]] = {}
 
 
 class ClientException(Exception):

--- a/engine/src/hopeit/server/api.py
+++ b/engine/src/hopeit/server/api.py
@@ -72,7 +72,7 @@ logger = engine_logger()
 swagger: Optional[Swagger] = None
 spec: Optional[dict] = None
 static_spec: Optional[dict] = None
-runtime_schemas = {}
+runtime_schemas: Dict[str, JsonSchemaValue] = {}
 _options = {"generate_mode": False}
 
 OPEN_API_VERSION = "3.0.3"

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -38,8 +38,6 @@ class StreamsConfig:
     :stream_manager: str: Stream manager class name. Default is "hopeit.streams.NoStreamManager".
     :field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379
         if using redis stream manager plugin to connect locally
-    :field username: SecretStr: Username for authentication. Default is an empty secret string.
-    :field password: SecretStr: Password for authentication. Default is an empty secret string.
     :field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.
         Default is 3 seconds.
     :field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.
@@ -48,11 +46,6 @@ class StreamsConfig:
         Default is 60.0 seconds.
     :field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.
         Default is 1.
-    :field max_connections: int: Maximum Redis connections per stream connection pool.
-        Default is 100.
-    :field pool_timeout: float: Maximum seconds to wait for an available Redis connection.
-        Default is 10.0.
-    :field protocol: int: Redis protocol version to use. Default is 2.
 
     Note:
         hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.
@@ -60,8 +53,6 @@ class StreamsConfig:
 
     stream_manager: str = "hopeit.streams.NoStreamManager"
     connection_str: str = "<<NoStreamManager>>"
-    # username: SecretStr = field(default_factory=partial(SecretStr, ""))
-    # password: SecretStr = field(default_factory=partial(SecretStr, ""))
     delay_auto_start_seconds: int = 3
     initial_backoff_seconds: float = 1.0
     max_backoff_seconds: float = 60.0

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -52,8 +52,8 @@ class StreamsConfig:
         Default is 1.
     :field max_connections: int: Maximum Redis connections per stream connection pool.
         Default is 100.
-    :field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.
-        Default is 20.0.
+    :field pool_timeout: float: Maximum seconds to wait for an available Redis connection.
+        Default is 10.0.
     :field protocol: int: Redis protocol version to use. Default is 2.
 
     Note:
@@ -69,7 +69,7 @@ class StreamsConfig:
     max_backoff_seconds: float = 60.0
     num_failures_open_circuit_breaker: int = 1
     max_connections: int = 100
-    blocking_pool_timeout: float = 20.0
+    pool_timeout: float = 10.0
     protocol: int = 2
 
 

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -50,6 +50,11 @@ class StreamsConfig:
         Default is 60.0 seconds.
     :field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.
         Default is 1.
+    :field max_connections: int: Maximum Redis connections per stream connection pool.
+        Default is 100.
+    :field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.
+        Default is 20.0.
+    :field protocol: int: Redis protocol version to use. Default is 2.
 
     Note:
         hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.
@@ -63,6 +68,9 @@ class StreamsConfig:
     initial_backoff_seconds: float = 1.0
     max_backoff_seconds: float = 60.0
     num_failures_open_circuit_breaker: int = 1
+    max_connections: int = 100
+    blocking_pool_timeout: float = 20.0
+    protocol: int = 2
 
 
 @dataobject

--- a/engine/src/hopeit/server/config.py
+++ b/engine/src/hopeit/server/config.py
@@ -6,8 +6,6 @@ from enum import Enum
 from typing import TypeVar, List, Optional
 import re
 import os
-from functools import partial
-from pydantic import SecretStr
 
 from hopeit.dataobjects import dataclass, dataobject, field
 from hopeit.dataobjects.payload import Payload
@@ -62,15 +60,12 @@ class StreamsConfig:
 
     stream_manager: str = "hopeit.streams.NoStreamManager"
     connection_str: str = "<<NoStreamManager>>"
-    username: SecretStr = field(default_factory=partial(SecretStr, ""))
-    password: SecretStr = field(default_factory=partial(SecretStr, ""))
+    # username: SecretStr = field(default_factory=partial(SecretStr, ""))
+    # password: SecretStr = field(default_factory=partial(SecretStr, ""))
     delay_auto_start_seconds: int = 3
     initial_backoff_seconds: float = 1.0
     max_backoff_seconds: float = 60.0
     num_failures_open_circuit_breaker: int = 1
-    max_connections: int = 100
-    pool_timeout: float = 10.0
-    protocol: int = 2
 
 
 @dataobject

--- a/engine/src/hopeit/server/job.py
+++ b/engine/src/hopeit/server/job.py
@@ -322,9 +322,12 @@ async def run_job(
                 streams_wait_on_stop=False,
             ).start()
             runtime.server.app_engines[config.app_key()] = app_engine
+            # Run standalone SETUP events before starting the next app. Some plugins
+            # initialize resources required by AppEngine.start(), so their config must
+            # precede dependent application configs in --config-files.
+            await _run_setup_events(app_engine, track_ids=track_ids)
 
         app_engine = runtime.server.app_engines[owner_config.app_key()]
-        await _run_setup_events(app_engine, track_ids=track_ids)
         for plugin in owner_config.plugins:
             plugin_engine = runtime.server.app_engines[plugin.app_key()]
             await _run_setup_events(

--- a/engine/src/hopeit/server/steps.py
+++ b/engine/src/hopeit/server/steps.py
@@ -440,8 +440,7 @@ class CollectorStepsDescriptor:
 async def _run_collector(
     step_group: CollectorStepsDescriptor, payload: EventPayload, context: EventContext
 ):
-    assert step_group.steps is not None
-    return await AsyncCollector().input(payload).steps(*step_group.steps).run(context)
+    return await AsyncCollector().input(payload).steps(*step_group.steps).run(context)  # type: ignore[misc]
 
 
 def _signature(

--- a/engine/src/hopeit/server/steps.py
+++ b/engine/src/hopeit/server/steps.py
@@ -440,6 +440,7 @@ class CollectorStepsDescriptor:
 async def _run_collector(
     step_group: CollectorStepsDescriptor, payload: EventPayload, context: EventContext
 ):
+    assert step_group.steps is not None
     return await AsyncCollector().input(payload).steps(*step_group.steps).run(context)
 
 

--- a/engine/src/hopeit/server/version.py
+++ b/engine/src/hopeit/server/version.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 ENGINE_NAME = "hopeit.engine"
-ENGINE_VERSION = "0.29.0"
+ENGINE_VERSION = "0.30.0"
 
 # Major.Minor version to be used in App versions and Api endpoints for Apps/Plugins
 APPS_API_VERSION = ".".join(ENGINE_VERSION.split(".")[0:2])

--- a/engine/src/hopeit/server/web.py
+++ b/engine/src/hopeit/server/web.py
@@ -77,7 +77,7 @@ extra = extra_logger()
 ResponseType = Union[web.Response, web.FileResponse, web.StreamResponse]
 
 web_server = web.Application()
-auth_info_default = {}
+auth_info_default: Dict[str, str] = {}
 
 
 def prepare_engine(

--- a/engine/test/integration/cli/test_run_job.py
+++ b/engine/test/integration/cli/test_run_job.py
@@ -96,6 +96,7 @@ def test_hopeit_job():
         "-m",
         "hopeit.cli.job",
         "--config-files=engine/config/dev-noauth.json"
+        ",plugins/streams/redis/config/plugin-config.json"
         ",plugins/auth/basic-auth/config/plugin-config.json"
         ",apps/examples/simple-example/config/app-config.json",
         "--event-name=check_enum",
@@ -103,8 +104,11 @@ def test_hopeit_job():
     ]
 
     mock_env = os.environ.copy()
+    mock_env["REDIS_USERNAME"] = ""
+    mock_env["REDIS_PASSWORD"] = ""
     mock_env["PYTHONPATH"] = (
-        "apps/examples/simple-example/src/:plugins/auth/basic-auth/src/:" + mock_env["PYTHONPATH"]
+        "apps/examples/simple-example/src/:plugins/auth/basic-auth/src/:plugins/streams/redis/src/:"
+        + mock_env.get("PYTHONPATH", "")
     )
 
     hopeit_proc = subprocess.Popen(

--- a/plugins/auth/basic-auth/pyproject.toml
+++ b/plugins/auth/basic-auth/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hopeit.basic-auth"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Example Basic Auth Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0", 
+    "hopeit.engine>=0.30.0", 
 ]
 
 license = "Apache-2.0"

--- a/plugins/clients/apps-client/pyproject.toml
+++ b/plugins/clients/apps-client/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hopeit.apps-client"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Apps Client Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
+    "hopeit.engine>=0.30.0",
 ]
 
 license = "Apache-2.0"

--- a/plugins/data/dataframes/pyproject.toml
+++ b/plugins/data/dataframes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hopeit.dataframes"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Dataframes for Polars"
 dynamic = ["readme"]
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "hopeit.fs-storage>=0.29.0",
+    "hopeit.engine>=0.30.0",
+    "hopeit.fs-storage>=0.30.0",
 ]
 
 [project.optional-dependencies]

--- a/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
+++ b/plugins/data/dataframes/src/hopeit/dataframes/serialization/files.py
@@ -70,7 +70,7 @@ class DatasetFileStorage(Generic[DataFrameT]):
         """
         datatype: Type[DataFrameT] = type(dataframe)
         return await self.save_df(
-            dataframe._df.select(datatype.__dataframe__.columns),
+            dataframe._df.select(datatype.__dataframe__.columns),  # type: ignore[misc]
             datatype,
             partition_dt=partition_dt,
             database_key=database_key,

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -941,7 +941,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -983,6 +983,21 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
+            "type": "integer"
+          },
+          "max_connections": {
+            "default": 100,
+            "title": "Max Connections",
+            "type": "integer"
+          },
+          "blocking_pool_timeout": {
+            "default": 20.0,
+            "title": "Blocking Pool Timeout",
+            "type": "number"
+          },
+          "protocol": {
+            "default": 2,
+            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/plugins/ops/apps-visualizer/api/openapi.json
+++ b/plugins/ops/apps-visualizer/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.29",
+    "version": "0.30",
     "title": "Simple Example",
     "description": "Simple Example"
   },
   "paths": {
-    "/api/config-manager/0x29/runtime-apps-config": {
+    "/api/config-manager/0x30/runtime-apps-config": {
       "get": {
         "summary": "Config Manager: Runtime Apps Config",
         "description": "Returns the runtime config for the Apps running on this server",
@@ -62,11 +62,11 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
-    "/api/config-manager/0x29/cluster-apps-config": {
+    "/api/config-manager/0x30/cluster-apps-config": {
       "get": {
         "summary": "Config Manager: Cluster Apps Config",
         "description": "Handle remote access to runtime configuration for a group of hosts",
@@ -122,7 +122,7 @@
           }
         },
         "tags": [
-          "config_manager.0x29"
+          "config_manager.0x30"
         ]
       }
     },
@@ -209,11 +209,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x29"
+          "apps_visualizer.0x30"
         ]
       }
     },
-    "/api/apps-visualizer/0x29/apps/events-graph": {
+    "/api/apps-visualizer/0x30/apps/events-graph": {
       "get": {
         "summary": "App Visualizer: Events Graph Data",
         "description": "App Visualizer: Events Graph Data",
@@ -287,11 +287,11 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x29"
+          "apps_visualizer.0x30"
         ]
       }
     },
-    "/api/apps-visualizer/0x29/event-stats/live": {
+    "/api/apps-visualizer/0x30/event-stats/live": {
       "get": {
         "summary": "App Visualizer: Live Stats",
         "description": "App Visualizer: Live Stats",
@@ -365,7 +365,7 @@
           }
         },
         "tags": [
-          "apps_visualizer.0x29"
+          "apps_visualizer.0x30"
         ]
       }
     }
@@ -891,7 +891,7 @@
             "$ref": "#/components/schemas/APIConfig"
           },
           "engine_version": {
-            "default": "0.29.0",
+            "default": "0.30.0",
             "title": "Engine Version",
             "type": "string"
           }
@@ -941,7 +941,7 @@
         "type": "string"
       },
       "StreamsConfig": {
-        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field username: SecretStr: Username for authentication. Default is an empty secret string.\n:field password: SecretStr: Password for authentication. Default is an empty secret string.\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n:field max_connections: int: Maximum Redis connections per stream connection pool.\n    Default is 100.\n:field blocking_pool_timeout: float: Maximum seconds to wait for an available Redis connection.\n    Default is 20.0.\n:field protocol: int: Redis protocol version to use. Default is 2.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
+        "description": "Configuration class for stream connection settings.\n\n:stream_manager: str: Stream manager class name. Default is \"hopeit.streams.NoStreamManager\".\n:field connection_str: str, url to connect to streams server: i.e. redis://localhost:6379\n    if using redis stream manager plugin to connect locally\n:field delay_auto_start_seconds: int: Delay in seconds before auto-starting the stream.\n    Default is 3 seconds.\n:field initial_backoff_seconds: float: Initial backoff time in seconds for connection retries.\n    Default is 1.0 second.\n:field max_backoff_seconds: float: Maximum backoff time in seconds for connection retries.\n    Default is 60.0 seconds.\n:field num_failures_open_circuit_breaker: int: Number of failures before opening the circuit breaker.\n    Default is 1.\n\nNote:\n    hopeit.engine provides `hopeit.redis_streams.RedisStreamManager` as the default plugin for stream management.",
         "properties": {
           "stream_manager": {
             "default": "hopeit.streams.NoStreamManager",
@@ -952,18 +952,6 @@
             "default": "<<NoStreamManager>>",
             "title": "Connection Str",
             "type": "string"
-          },
-          "username": {
-            "format": "password",
-            "title": "Username",
-            "type": "string",
-            "writeOnly": true
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string",
-            "writeOnly": true
           },
           "delay_auto_start_seconds": {
             "default": 3,
@@ -983,21 +971,6 @@
           "num_failures_open_circuit_breaker": {
             "default": 1,
             "title": "Num Failures Open Circuit Breaker",
-            "type": "integer"
-          },
-          "max_connections": {
-            "default": 100,
-            "title": "Max Connections",
-            "type": "integer"
-          },
-          "blocking_pool_timeout": {
-            "default": 20.0,
-            "title": "Blocking Pool Timeout",
-            "type": "number"
-          },
-          "protocol": {
-            "default": 2,
-            "title": "Protocol",
             "type": "integer"
           }
         },

--- a/plugins/ops/apps-visualizer/pyproject.toml
+++ b/plugins/ops/apps-visualizer/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "hopeit.apps-visualizer"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Apps Visualizer Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "hopeit.config-manager>=0.29.0",
-    "hopeit.log-streamer>=0.29.0",
+    "hopeit.engine>=0.30.0",
+    "hopeit.config-manager>=0.30.0",
+    "hopeit.log-streamer>=0.30.0",
 ]
 
 license = "Apache-2.0"

--- a/plugins/ops/config-manager/pyproject.toml
+++ b/plugins/ops/config-manager/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hopeit.config-manager"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Config Manager Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0", 
+    "hopeit.engine>=0.30.0", 
 ]
 
 license = "Apache-2.0"

--- a/plugins/ops/log-streamer/pyproject.toml
+++ b/plugins/ops/log-streamer/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hopeit.log-streamer"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Log Streamer Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
+    "hopeit.engine>=0.30.0",
     "watchdog>=6.0.0",
 ]
 

--- a/plugins/storage/fs/pyproject.toml
+++ b/plugins/storage/fs/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hopeit.fs-storage"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine File System Storage Toolkit"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0", 
+    "hopeit.engine>=0.30.0", 
     "aiofiles>=24.1.0",
 ]
 

--- a/plugins/storage/redis/pyproject.toml
+++ b/plugins/storage/redis/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "hopeit.redis-storage"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Redis Storage Toolkit"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0", 
-    "redis>=7.1.0",
+    "hopeit.engine>=0.30.0", 
+    "redis>=8.0.0",
 ]
 
 license = "Apache-2.0"

--- a/plugins/streams/redis/config/plugin-config.json
+++ b/plugins/streams/redis/config/plugin-config.json
@@ -1,0 +1,31 @@
+{
+  "app": {
+    "name": "redis-streams",
+    "version": "${HOPEIT_APPS_API_VERSION}"
+  },
+  "engine": {
+    "import_modules": [
+      "hopeit.redis_streams"
+    ]
+  },
+  "settings": {
+    "redis_auth": {
+      "username": "${REDIS_USERNAME}",
+      "password": "${REDIS_PASSWORD}"
+    },
+    "redis_pool": {
+      "max_connections":  100,
+      "pool_timeout":  10.0,
+      "protocol":  2
+    }
+  },
+  "events": {
+    "setup_redis_pool": {
+      "type": "SETUP",
+      "setting_keys": [
+        "redis_auth",
+        "redis_pool"
+      ]
+    }
+  }
+}

--- a/plugins/streams/redis/pyproject.toml
+++ b/plugins/streams/redis/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "hopeit.redis-streams"
-version = "0.29.0"
+version = "0.30.0"
 
 description = "Hopeit Engine Redis Streams Plugin"
 dynamic = ["readme"]
 
 dependencies = [
-    "hopeit.engine>=0.29.0",
-    "redis>=7.1.0",
+    "hopeit.engine>=0.30.0",
+    "redis>=8.0.0",
 ]
 
 license = "Apache-2.0"

--- a/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Any, Union
 
 import redis.asyncio as redis
+from redis.asyncio.connection import BlockingConnectionPool
 from redis import RedisError, ResponseError
 from redis.exceptions import ConnectionError as RedisConnectionError
 
@@ -51,20 +52,23 @@ class RedisStreamManager(StreamManager):
         """
         logger.info(__name__, f"Connecting address={self.address}...")
         try:
-            self._write_pool = redis.from_url(
-                self.address,
-                username=config.username.get_secret_value(),
-                password=config.password.get_secret_value(),
-            )
-            self._read_pool = redis.from_url(
-                self.address,
-                username=config.username.get_secret_value(),
-                password=config.password.get_secret_value(),
-            )
+            self._write_pool = self._redis_client(config)
+            self._read_pool = self._redis_client(config)
             return self
         except (OSError, RedisError, RedisConnectionError) as e:  # pragma: no cover
             logger.error(__name__, e)
             raise StreamOSError(e) from e
+
+    def _redis_client(self, config: StreamsConfig) -> redis.Redis:
+        connection_pool: BlockingConnectionPool = BlockingConnectionPool.from_url(
+            self.address,
+            username=config.username.get_secret_value(),
+            password=config.password.get_secret_value(),
+            max_connections=config.max_connections,
+            timeout=config.blocking_pool_timeout,
+            protocol=config.protocol,
+        )
+        return redis.Redis(connection_pool=connection_pool)
 
     async def close(self):
         """
@@ -73,7 +77,10 @@ class RedisStreamManager(StreamManager):
 
         async def _close(pool) -> None:
             if pool:
-                await pool.close()
+                if hasattr(pool, "aclose"):
+                    await pool.aclose(close_connection_pool=True)
+                else:
+                    await pool.close()
             return None
 
         self._read_pool = await _close(self._read_pool)

--- a/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
@@ -8,10 +8,9 @@ import json
 import base64
 import uuid
 from datetime import datetime, timezone
-from typing import Dict, List, Any, Union
+from typing import Callable, Dict, List, Any, Optional, Union
 
 import redis.asyncio as redis
-from redis.asyncio.connection import BlockingConnectionPool
 from redis import RedisError, ResponseError
 from redis.exceptions import ConnectionError as RedisConnectionError
 
@@ -27,11 +26,30 @@ extra = extra_logger()
 
 DEFAULT_QUEUE = StreamQueue.AUTO.encode()
 
+ConnectionFactory = Callable[[StreamsConfig], redis.Redis]
+
 
 class RedisStreamManager(StreamManager):
     """
     Manages streams of a Hopeit App
     """
+
+    # __connection_factory must be initialized during redis_streams plugin setup event
+    __connection_factory: Optional[ConnectionFactory] = None
+
+    @classmethod
+    def connection_factory(cls, config: StreamsConfig) -> redis.Redis:
+        assert cls.__connection_factory is not None, (
+            "Redis Streams connection factory not initialized. Check if Redis Streams plugin `setup_redis_pool` event not configured"
+        )
+        return cls.__connection_factory(config)
+
+    @classmethod
+    def setup_connection_factory(cls, connection_factory: ConnectionFactory):
+        assert cls.__connection_factory is None, (
+            "Redis Streams connection factory already initialized."
+        )
+        cls.__connection_factory = connection_factory
 
     def __init__(self, *, address: str):
         """
@@ -52,23 +70,23 @@ class RedisStreamManager(StreamManager):
         """
         logger.info(__name__, f"Connecting address={self.address}...")
         try:
-            self._write_pool = self._redis_client(config)
-            self._read_pool = self._redis_client(config)
+            self._write_pool = self.connection_factory(config)
+            self._read_pool = self.connection_factory(config)
             return self
         except (OSError, RedisError, RedisConnectionError) as e:  # pragma: no cover
             logger.error(__name__, e)
             raise StreamOSError(e) from e
 
-    def _redis_client(self, config: StreamsConfig) -> redis.Redis:
-        connection_pool: BlockingConnectionPool = BlockingConnectionPool.from_url(
-            self.address,
-            username=config.username.get_secret_value(),
-            password=config.password.get_secret_value(),
-            max_connections=config.max_connections,
-            timeout=config.pool_timeout,
-            protocol=config.protocol,
-        )
-        return redis.Redis(connection_pool=connection_pool)
+    # def _redis_client(self, config: StreamsConfig) -> redis.Redis:
+    #     connection_pool: BlockingConnectionPool = BlockingConnectionPool.from_url(
+    #         self.address,
+    #         # username=config.username.get_secret_value(),
+    #         # password=config.password.get_secret_value(),
+    #         # max_connections=config.max_connections,
+    #         # timeout=config.pool_timeout,
+    #         # protocol=config.protocol,
+    #     )
+    #     return redis.Redis(connection_pool=connection_pool)
 
     async def close(self):
         """

--- a/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
@@ -65,7 +65,7 @@ class RedisStreamManager(StreamManager):
             username=config.username.get_secret_value(),
             password=config.password.get_secret_value(),
             max_connections=config.max_connections,
-            timeout=config.blocking_pool_timeout,
+            timeout=config.pool_timeout,
             protocol=config.protocol,
         )
         return redis.Redis(connection_pool=connection_pool)

--- a/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
@@ -26,7 +26,7 @@ extra = extra_logger()
 
 DEFAULT_QUEUE = StreamQueue.AUTO.encode()
 
-ConnectionFactory = Callable[[StreamsConfig], redis.Redis]
+ConnectionFactory = Callable[[str], redis.Redis]
 
 
 class RedisStreamManager(StreamManager):
@@ -38,11 +38,11 @@ class RedisStreamManager(StreamManager):
     __connection_factory: Optional[ConnectionFactory] = None
 
     @classmethod
-    def connection_factory(cls, config: StreamsConfig) -> redis.Redis:
+    def connection_factory(cls, address: str) -> redis.Redis:
         assert cls.__connection_factory is not None, (
             "Redis Streams connection factory not initialized. Check if Redis Streams plugin `setup_redis_pool` event not configured"
         )
-        return cls.__connection_factory(config)
+        return cls.__connection_factory(address)
 
     @classmethod
     def setup_connection_factory(cls, connection_factory: ConnectionFactory):
@@ -70,8 +70,8 @@ class RedisStreamManager(StreamManager):
         """
         logger.info(__name__, f"Connecting address={self.address}...")
         try:
-            self._write_pool = self.connection_factory(config)
-            self._read_pool = self.connection_factory(config)
+            self._write_pool = self.connection_factory(self.address)
+            self._read_pool = self.connection_factory(self.address)
             return self
         except (OSError, RedisError, RedisConnectionError) as e:  # pragma: no cover
             logger.error(__name__, e)

--- a/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/__init__.py
@@ -1,7 +1,4 @@
-"""
-Streams module. Handles reading and writing to streams.
-Backed by Redis Streams
-"""
+"""Redis Streams-backed implementation of the Hopeit stream manager."""
 
 import asyncio
 import json
@@ -30,9 +27,7 @@ ConnectionFactory = Callable[[str], redis.Redis]
 
 
 class RedisStreamManager(StreamManager):
-    """
-    Manages streams of a Hopeit App
-    """
+    """Manage Hopeit application streams using Redis Streams."""
 
     # __connection_factory must be initialized during redis_streams plugin setup event
     __connection_factory: Optional[ConnectionFactory] = None
@@ -53,9 +48,9 @@ class RedisStreamManager(StreamManager):
 
     def __init__(self, *, address: str):
         """
-        Creates an StreamManager instance backed by redis connection
-        specified in `address`.
-        After creation, `connect()` must be called to create connection pools.
+        Create a stream manager for the Redis server at ``address``.
+
+        ``connect()`` must be called before the manager is used.
         """
         self.address = address
         self.consumer_id = self._consumer_id()
@@ -64,9 +59,13 @@ class RedisStreamManager(StreamManager):
 
     async def connect(self, config: StreamsConfig) -> StreamManager:
         """
-        Connects to Redis using two connection pools, one to handle
-        writing to stream and one for reading.
-        :param config: StreamsConfig: The configuration object containing the Redis connection details.
+        Create separate Redis clients for stream reads and writes.
+
+        The clients and their connection pools are created by the factory initialized
+        by the Redis Streams plugin SETUP event.
+
+        :param config: Engine stream configuration required by the StreamManager interface.
+        :return: This connected stream manager.
         """
         logger.info(__name__, f"Connecting address={self.address}...")
         try:
@@ -77,28 +76,12 @@ class RedisStreamManager(StreamManager):
             logger.error(__name__, e)
             raise StreamOSError(e) from e
 
-    # def _redis_client(self, config: StreamsConfig) -> redis.Redis:
-    #     connection_pool: BlockingConnectionPool = BlockingConnectionPool.from_url(
-    #         self.address,
-    #         # username=config.username.get_secret_value(),
-    #         # password=config.password.get_secret_value(),
-    #         # max_connections=config.max_connections,
-    #         # timeout=config.pool_timeout,
-    #         # protocol=config.protocol,
-    #     )
-    #     return redis.Redis(connection_pool=connection_pool)
-
     async def close(self):
-        """
-        Close connections to Redis
-        """
+        """Close both Redis clients and their connection pools."""
 
         async def _close(pool) -> None:
             if pool:
-                if hasattr(pool, "aclose"):
-                    await pool.aclose(close_connection_pool=True)
-                else:
-                    await pool.close()
+                await pool.aclose(close_connection_pool=True)
             return None
 
         self._read_pool = await _close(self._read_pool)
@@ -124,6 +107,7 @@ class RedisStreamManager(StreamManager):
         :param track_ids: dict with key and id values to track in stream event
         :param auth_info: dict with auth info to be tracked as part of stream event
         :param compression: Compression, supported compression algorithm from enum
+        :param serialization: Serialization, supported serialization format from enum
         :param target_max_len: int, max_len to indicate approx. target collection size to Redis,
             default 0 will not send max_len to Redis.
         :return: number of successful written messages
@@ -144,11 +128,12 @@ class RedisStreamManager(StreamManager):
 
     async def ensure_consumer_group(self, *, stream_name: str, consumer_group: str):
         """
-        Ensures a consumer_group exists for a given stream.
-        If group does not exists, XGROUP_CREATE will be executed in Redis and consumer group
-        created to consume event from beginning of stream (from id=0)
-        If group already exists a message will be logged and no action performed.
-        If stream does not exists and empty stream will be created.
+        Ensure a consumer group exists for a given stream.
+
+        If the group does not exist, ``XGROUP CREATE`` creates it at ID 0 so it consumes
+        from the beginning of the stream. If the stream does not exist, an empty stream
+        is created. If the group already exists, no action is performed.
+
         :param stream_name: str, stream name or key used by Redis
         :param consumer_group: str, consumer group passed to Redis
         """
@@ -179,12 +164,12 @@ class RedisStreamManager(StreamManager):
         batch_interval: int,
     ) -> List[Union[StreamEvent, Exception]]:
         """
-        Attempts reading streams using a consumer group,
-        blocks for `timeout` seconds
-        and yields asynchronously the deserialized objects gotten from the stream.
-        In case timeout is reached, nothing is yielded
-        and read_stream must be called again,
-        usually in an infinite loop while app is running.
+        Read a batch of events using a Redis consumer group.
+
+        The Redis read blocks for up to ``timeout`` milliseconds. If no messages are
+        returned, this method waits for ``batch_interval`` milliseconds and returns an
+        empty list.
+
         :param stream_name: str, stream name or key used by Redis, including queue suffix if necessary.
         :param consumer_group: str, consumer group registered in Redis
         :param datatypes: Dict[str, type] supported datatypes name: type to be extracted from stream.
@@ -196,8 +181,7 @@ class RedisStreamManager(StreamManager):
         :param timeout: time to block waiting for messages, in milliseconds
         :param batch_interval: int, time to sleep between requests to connection pool in case no
             messages are returned. In milliseconds. Used to prevent blocking the pool.
-        :param compression: Compression, supported compression algorithm from enum
-        :return: yields Tuples of message id (bytes) and deserialized DataObject
+        :return: A list containing decoded stream events or per-message decoding errors.
         """
         try:
             response = await self._read_pool.xreadgroup(
@@ -319,7 +303,7 @@ class RedisStreamManager(StreamManager):
         track_headers: List[str],
         read_ts: str,
     ):
-        """Decodes/deserialize message from stream"""
+        """Decode and deserialize a message from a Redis stream."""
         assert isinstance(msg[0], bytes) and isinstance(msg[1], dict), (
             "Invalid message format. Expected `[bytes, bytes, Dict[bytes, bytes]]`"
         )

--- a/plugins/streams/redis/src/hopeit/redis_streams/settings.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/settings.py
@@ -1,0 +1,19 @@
+from functools import partial
+
+from hopeit.dataobjects import dataclass, dataobject, field
+from pydantic import SecretStr
+
+
+@dataobject
+@dataclass
+class RedisAuthSettings:
+    username: SecretStr = field(default_factory=partial(SecretStr, ""))
+    password: SecretStr = field(default_factory=partial(SecretStr, ""))
+
+
+@dataobject
+@dataclass
+class RedisPoolSettings:
+    max_connections: int = 100
+    pool_timeout: float = 10.0
+    protocol: int = 2

--- a/plugins/streams/redis/src/hopeit/redis_streams/settings.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/settings.py
@@ -7,6 +7,13 @@ from pydantic import SecretStr
 @dataobject
 @dataclass
 class RedisAuthSettings:
+    """
+    Redis authentication settings.
+
+    :field username: SecretStr: Username for authentication. Default is an empty secret string.
+    :field password: SecretStr: Password for authentication. Default is an empty secret string.
+    """
+
     username: SecretStr = field(default_factory=partial(SecretStr, ""))
     password: SecretStr = field(default_factory=partial(SecretStr, ""))
 
@@ -14,6 +21,16 @@ class RedisAuthSettings:
 @dataobject
 @dataclass
 class RedisPoolSettings:
+    """
+    Redis connection pool settings.
+
+    :field max_connections: int: Maximum Redis connections per stream connection pool.
+        Default is 100.
+    :field pool_timeout: float: Maximum seconds to wait for an available Redis connection.
+        Default is 10.0.
+    :field protocol: int: Redis protocol version to use. Default is 2.
+    """
+
     max_connections: int = 100
     pool_timeout: float = 10.0
     protocol: int = 2

--- a/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
@@ -1,0 +1,34 @@
+"""Intial setup event for experiment and model storage"""
+
+from hopeit.app.context import EventContext
+from hopeit.redis_streams import RedisStreamManager
+from hopeit.redis_streams.settings import RedisAuthSettings, RedisPoolSettings
+from hopeit.server.config import StreamsConfig
+
+import redis.asyncio as redis
+from redis.asyncio import BlockingConnectionPool
+
+
+__steps__ = [
+    "init_redis_streams",
+]
+
+
+async def init_redis_streams(payload: None, context: EventContext) -> None:
+    auth_settings = context.settings(key="redis_auth", datatype=RedisAuthSettings)
+    pool_settings = context.settings(key="redis_pool", datatype=RedisPoolSettings)
+
+    def connection_factory(config: StreamsConfig):
+        print(config)
+        return redis.Redis(
+            connection_pool=BlockingConnectionPool.from_url(
+                config.connection_str,
+                username=auth_settings.username.get_secret_value(),
+                password=auth_settings.password.get_secret_value(),
+                max_connections=pool_settings.max_connections,
+                timeout=pool_settings.pool_timeout,
+                protocol=pool_settings.protocol,
+            )
+        )
+
+    RedisStreamManager.setup_connection_factory(connection_factory)

--- a/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
@@ -3,7 +3,6 @@
 from hopeit.app.context import EventContext
 from hopeit.redis_streams import RedisStreamManager
 from hopeit.redis_streams.settings import RedisAuthSettings, RedisPoolSettings
-from hopeit.server.config import StreamsConfig
 
 import redis.asyncio as redis
 from redis.asyncio import BlockingConnectionPool
@@ -18,11 +17,10 @@ async def init_redis_streams(payload: None, context: EventContext) -> None:
     auth_settings = context.settings(key="redis_auth", datatype=RedisAuthSettings)
     pool_settings = context.settings(key="redis_pool", datatype=RedisPoolSettings)
 
-    def connection_factory(config: StreamsConfig):
-        print(config)
+    def connection_factory(address: str):
         return redis.Redis(
             connection_pool=BlockingConnectionPool.from_url(
-                config.connection_str,
+                address,
                 username=auth_settings.username.get_secret_value(),
                 password=auth_settings.password.get_secret_value(),
                 max_connections=pool_settings.max_connections,

--- a/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
+++ b/plugins/streams/redis/src/hopeit/redis_streams/setup_redis_pool.py
@@ -1,4 +1,4 @@
-"""Intial setup event for experiment and model storage"""
+"""SETUP event that configures Redis Streams clients with blocking connection pools."""
 
 from hopeit.app.context import EventContext
 from hopeit.redis_streams import RedisStreamManager

--- a/plugins/streams/redis/test/unit/test_redis_streams.py
+++ b/plugins/streams/redis/test/unit/test_redis_streams.py
@@ -1,16 +1,28 @@
 import asyncio
 
+from hopeit.redis_streams import setup_redis_pool
 import redis.asyncio as redis
 from redis import ResponseError
 
 from datetime import datetime, timezone
 
-from hopeit.app.config import Compression, Serialization
+from hopeit.app.config import (
+    AppConfig,
+    AppDescriptor,
+    AppEngineConfig,
+    Compression,
+    EventDescriptor,
+    EventType,
+    Serialization,
+)
 from hopeit.dataobjects import dataclass, dataobject
 from hopeit.server.config import AuthType, StreamsConfig
+from hopeit.server.version import APPS_API_VERSION
+from hopeit.testing.apps import create_test_context
 
 from hopeit.streams import StreamEvent
-from hopeit.redis_streams import BlockingConnectionPool, RedisStreamManager
+from hopeit.redis_streams import RedisStreamManager
+from hopeit.redis_streams.setup_redis_pool import BlockingConnectionPool
 
 from . import MockEventHandler, TestStreamData
 from copy import deepcopy
@@ -30,6 +42,33 @@ class MockInvalidDataEvent:
 
 async def create_stream_manager():
     settings = StreamsConfig()
+    plugin_config = AppConfig(
+        app=AppDescriptor(name="redis-streams", version=APPS_API_VERSION),
+        engine=AppEngineConfig(import_modules=["hopeit.redis_streams"]),
+        settings={
+            "redis_auth": {
+                "username": "",
+                "password": "",
+            },
+            "redis_pool": {
+                "max_connections": 100,
+                "pool_timeout": 10.0,
+                "protocol": 2,
+            },
+        },
+        events={
+            "setup_redis_pool": EventDescriptor(
+                type=EventType.SETUP,
+                setting_keys=[
+                    "redis_auth",
+                    "redis_pool",
+                ],
+            ),
+        },
+    ).setup()
+    context = create_test_context(plugin_config, "setup_redis_pool")
+    RedisStreamManager._RedisStreamManager__connection_factory = None
+    await setup_redis_pool.init_redis_streams(None, context)
     return await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
 
 

--- a/plugins/streams/redis/test/unit/test_redis_streams.py
+++ b/plugins/streams/redis/test/unit/test_redis_streams.py
@@ -40,8 +40,10 @@ class MockInvalidDataEvent:
     value: str
 
 
-async def create_stream_manager():
-    settings = StreamsConfig()
+async def create_stream_manager(
+    *, max_connections: int = 3, pool_timeout: float = 2.5, protocol: int = 2
+):
+    stream_config = StreamsConfig()
     plugin_config = AppConfig(
         app=AppDescriptor(name="redis-streams", version=APPS_API_VERSION),
         engine=AppEngineConfig(import_modules=["hopeit.redis_streams"]),
@@ -51,9 +53,9 @@ async def create_stream_manager():
                 "password": "",
             },
             "redis_pool": {
-                "max_connections": 3,
-                "pool_timeout": 2.5,
-                "protocol": 2,
+                "max_connections": max_connections,
+                "pool_timeout": pool_timeout,
+                "protocol": protocol,
             },
         },
         events={
@@ -67,9 +69,9 @@ async def create_stream_manager():
         },
     ).setup()
     context = create_test_context(plugin_config, "setup_redis_pool")
-    RedisStreamManager._RedisStreamManager__connection_factory = None
+    setattr(RedisStreamManager, "_RedisStreamManager__connection_factory", None)
     await setup_redis_pool.init_redis_streams(None, context)
-    return await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+    return await RedisStreamManager(address=MockRedisPool.test_url).connect(stream_config)
 
 
 def patch_redis_client(monkeypatch):
@@ -240,8 +242,7 @@ async def test_ack_read_stream(monkeypatch):
 
 async def test_connect_uses_blocking_pool_settings(monkeypatch):
     patch_redis_client(monkeypatch)
-    settings = StreamsConfig(max_connections=3, pool_timeout=2.5, protocol=2)
-    mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+    mgr = await create_stream_manager(max_connections=3, pool_timeout=2.5, protocol=2)
     assert mgr._write_pool.connection_kwargs == {
         "username": "",
         "password": "",
@@ -258,8 +259,7 @@ async def test_connect_uses_blocking_pool_settings(monkeypatch):
 
 async def test_write_stream_concurrent_low_max_connections(monkeypatch):
     patch_redis_client(monkeypatch)
-    settings = StreamsConfig(max_connections=2, pool_timeout=2.5)
-    mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+    mgr = await create_stream_manager(max_connections=2, pool_timeout=2.5)
     payload = MockData("test_value", datetime.fromtimestamp(0, tz=timezone.utc))
     results = await asyncio.gather(
         *(
@@ -276,7 +276,7 @@ async def test_write_stream_concurrent_low_max_connections(monkeypatch):
         )
     )
     assert results == [1] * 10
-    assert mgr._write_pool.max_active_connections <= 3
+    assert mgr._write_pool.max_active_connections <= 2
     await mgr.close()
 
 

--- a/plugins/streams/redis/test/unit/test_redis_streams.py
+++ b/plugins/streams/redis/test/unit/test_redis_streams.py
@@ -201,7 +201,7 @@ async def test_ack_read_stream(monkeypatch):
 
 async def test_connect_uses_blocking_pool_settings(monkeypatch):
     patch_redis_client(monkeypatch)
-    settings = StreamsConfig(max_connections=3, blocking_pool_timeout=2.5, protocol=2)
+    settings = StreamsConfig(max_connections=3, pool_timeout=2.5, protocol=2)
     mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
     assert mgr._write_pool.connection_kwargs == {
         "username": "",
@@ -219,7 +219,7 @@ async def test_connect_uses_blocking_pool_settings(monkeypatch):
 
 async def test_write_stream_concurrent_low_max_connections(monkeypatch):
     patch_redis_client(monkeypatch)
-    settings = StreamsConfig(max_connections=2, blocking_pool_timeout=2.5)
+    settings = StreamsConfig(max_connections=2, pool_timeout=2.5)
     mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
     payload = MockData("test_value", datetime.fromtimestamp(0, tz=timezone.utc))
     results = await asyncio.gather(

--- a/plugins/streams/redis/test/unit/test_redis_streams.py
+++ b/plugins/streams/redis/test/unit/test_redis_streams.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import redis.asyncio as redis
 from redis import ResponseError
 
@@ -8,7 +10,7 @@ from hopeit.dataobjects import dataclass, dataobject
 from hopeit.server.config import AuthType, StreamsConfig
 
 from hopeit.streams import StreamEvent
-from hopeit.redis_streams import RedisStreamManager
+from hopeit.redis_streams import BlockingConnectionPool, RedisStreamManager
 
 from . import MockEventHandler, TestStreamData
 from copy import deepcopy
@@ -29,6 +31,11 @@ class MockInvalidDataEvent:
 async def create_stream_manager():
     settings = StreamsConfig()
     return await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+
+
+def patch_redis_client(monkeypatch):
+    monkeypatch.setattr(BlockingConnectionPool, "from_url", MockRedisPool.from_url)
+    monkeypatch.setattr(redis, "Redis", MockRedisPool.redis)
 
 
 async def write_stream():
@@ -151,22 +158,22 @@ async def ack_read_stream():
 
 
 async def test_write_stream(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     await write_stream()
 
 
 async def test_ensure_consume_group(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     await ensure_consumer_group()
 
 
 async def test_read_stream(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     await read_stream()
 
 
 async def test_read_stream_queue_name(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     monkeypatch.setattr(TestStreamData, "test_queue", "custom")
     test_msg = deepcopy(MockRedisPool.test_msg)
     test_msg[1][b"queue"] = b"custom"
@@ -175,7 +182,7 @@ async def test_read_stream_queue_name(monkeypatch):
 
 
 async def test_read_stream_default_queue_name_when_missing(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     test_msg = deepcopy(MockRedisPool.test_msg)
     del test_msg[1][b"queue"]
     monkeypatch.setattr(MockRedisPool, "test_msg", test_msg)
@@ -183,13 +190,55 @@ async def test_read_stream_default_queue_name_when_missing(monkeypatch):
 
 
 async def test_read_stream_empty_batch(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     await read_stream_empty_batch()
 
 
 async def test_ack_read_stream(monkeypatch):
-    monkeypatch.setattr(redis, "from_url", MockRedisPool.from_url)
+    patch_redis_client(monkeypatch)
     await ack_read_stream()
+
+
+async def test_connect_uses_blocking_pool_settings(monkeypatch):
+    patch_redis_client(monkeypatch)
+    settings = StreamsConfig(max_connections=3, blocking_pool_timeout=2.5, protocol=2)
+    mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+    assert mgr._write_pool.connection_kwargs == {
+        "username": "",
+        "password": "",
+        "max_connections": 3,
+        "timeout": 2.5,
+        "protocol": 2,
+    }
+    assert mgr._read_pool.connection_kwargs == mgr._write_pool.connection_kwargs
+    assert mgr._write_pool is not mgr._read_pool
+    await mgr.close()
+    assert mgr._write_pool is None
+    assert mgr._read_pool is None
+
+
+async def test_write_stream_concurrent_low_max_connections(monkeypatch):
+    patch_redis_client(monkeypatch)
+    settings = StreamsConfig(max_connections=2, blocking_pool_timeout=2.5)
+    mgr = await RedisStreamManager(address=MockRedisPool.test_url).connect(settings)
+    payload = MockData("test_value", datetime.fromtimestamp(0, tz=timezone.utc))
+    results = await asyncio.gather(
+        *(
+            mgr.write_stream(
+                stream_name="test_stream",
+                queue=TestStreamData.test_queue,
+                payload=payload,
+                track_ids=MockEventHandler.test_track_ids,
+                auth_info={"auth_type": AuthType.UNSECURED, "allowed": "true"},
+                compression=Compression.NONE,
+                serialization=Serialization.JSON_UTF8,
+            )
+            for _ in range(10)
+        )
+    )
+    assert results == [1] * 10
+    assert mgr._write_pool.max_active_connections <= 2
+    await mgr.close()
 
 
 class MockRedisPool:
@@ -213,7 +262,12 @@ class MockRedisPool:
         },
     ]
 
-    def __init__(self):
+    def __init__(self, *, connection_kwargs=None):
+        self.connection_kwargs = connection_kwargs or {}
+        max_connections = self.connection_kwargs.get("max_connections")
+        self._semaphore = asyncio.Semaphore(max_connections) if max_connections else None
+        self._active_connections = 0
+        self.max_active_connections = 0
         self.xadd_name = None
         self.xadd_fields = None
         self.xadd_maxlen = None
@@ -225,18 +279,35 @@ class MockRedisPool:
         self.xread_consumername = None
         self.xack_msg_id = None
         self.closed = False
+        self.aclosed = False
 
     @staticmethod
-    def from_url(url, username, password):
+    def from_url(url, **kwargs):
         assert url == MockRedisPool.test_url
-        return MockRedisPool()
+        return MockRedisPool(connection_kwargs=kwargs)
+
+    @staticmethod
+    def redis(*, connection_pool):
+        return connection_pool
 
     async def xadd(self, name, fields, id=b"*", maxlen=None, approximate=True):
-        self.xadd_name = name
-        self.xadd_fields = fields
-        self.xadd_maxlen = maxlen
-        self.xadd_approximate = approximate
-        return 1
+        if self._semaphore:
+            async with self._semaphore:
+                return await self._xadd(name, fields, id, maxlen, approximate)
+        return await self._xadd(name, fields, id, maxlen, approximate)
+
+    async def _xadd(self, name, fields, id=b"*", maxlen=None, approximate=True):
+        self._active_connections += 1
+        self.max_active_connections = max(self.max_active_connections, self._active_connections)
+        await asyncio.sleep(0)
+        try:
+            self.xadd_name = name
+            self.xadd_fields = fields
+            self.xadd_maxlen = maxlen
+            self.xadd_approximate = approximate
+            return 1
+        finally:
+            self._active_connections -= 1
 
     async def xgroup_create(self, name, groupname, id="$", mkstream=False):
         if self.xgroup_name == name and self.xgroup_groupname == groupname:
@@ -263,3 +334,7 @@ class MockRedisPool:
 
     async def close(self):
         self.closed = True
+
+    async def aclose(self, close_connection_pool=None):
+        assert close_connection_pool is True
+        self.aclosed = True

--- a/plugins/streams/redis/test/unit/test_redis_streams.py
+++ b/plugins/streams/redis/test/unit/test_redis_streams.py
@@ -51,8 +51,8 @@ async def create_stream_manager():
                 "password": "",
             },
             "redis_pool": {
-                "max_connections": 100,
-                "pool_timeout": 10.0,
+                "max_connections": 3,
+                "pool_timeout": 2.5,
                 "protocol": 2,
             },
         },
@@ -276,7 +276,7 @@ async def test_write_stream_concurrent_low_max_connections(monkeypatch):
         )
     )
     assert results == [1] * 10
-    assert mgr._write_pool.max_active_connections <= 2
+    assert mgr._write_pool.max_active_connections <= 3
     await mgr.close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hopeit.engine.workspace"
-version = "0.29.0"
+version = "0.30.0"
 
 dynamic = ["readme"]
 
@@ -72,22 +72,22 @@ package = false
 
 [dependency-groups]
 dev = [
-    "mypy>=1.13.0",
-    "pytest>=8.3.3",
-    "pytest-cov>=6.0.0",
-    "pytest-aiohttp>=1.1.0",
-    "pytest-asyncio>=0.25.3,<1.1",  # Used by pytest-aiohttp
-    "pytest-order>=1.3.0",
-    "pytest-mock>=3.14.0",
-    "coverage>=7.6.12",
-    "ruff>=0.9.7",
-    "isort>=5.13.2",
-    "aiofiles>=24.1.0",
+    "mypy>=2.1.0",
+    "pytest>=8.4.1",
+    "pytest-cov>=7.1.0",
+    "pytest-aiohttp>=1.1.1",
+    "pytest-asyncio>=1.0.0,<1.1",  # Used by pytest-aiohttp
+    "pytest-order>=1.5.0",
+    "pytest-mock>=3.15.1",
+    "coverage>=7.14.1",
+    "ruff>=0.15.18",
+    "isort>=8.0.1",
+    "aiofiles>=25.1.0",
     "nest-asyncio>=1.6.0",
     # type stubs
-    "types-aiofiles>=24.1.0",
+    "types-aiofiles>=25.1.0",
     "types-redis>=4.6.0",
-    "types-gunicorn>=23.0.0",
+    "types-gunicorn>=26.0.0",
     # examples/dataframes-example runtime deps
     "numpy>=2",
     "scikit-learn>=1.6.1",


### PR DESCRIPTION
This PR updates `hopeit.redis_streams.RedisStreamManager` to use `redis.asyncio.connection.BlockingConnectionPool` instead of the default async Redis connection pool.

It also exposes Redis stream pool settings through `StreamsConfig`:

- `max_connections`, default `100`
- `blocking_pool_timeout`, default `20.0`
- `protocol`, default `2`

### Problem

With `redis==7.4.1`, the default async `ConnectionPool` effectively allowed a very high number of connections.

With `redis==8.0.0`, the default changed to `100`. Since the regular pool raises immediately when exhausted, concurrent Redis Stream writes can fail with:

`redis.exceptions.MaxConnectionsError: Too many connections`

This can happen when Hopeit publishes an event result or downstream event through `write_stream(...)`, specifically during `XADD`.

### Fix
Fixes #222 

`RedisStreamManager` now creates separate read and write Redis clients backed by `BlockingConnectionPool`.

When the pool reaches `max_connections`, concurrent operations wait up to `blocking_pool_timeout` for an available connection instead of failing immediately.

The Redis client shutdown path was also updated to use `aclose(close_connection_pool=True)` when available, with a fallback to `close()`.

### Tests

Added unit coverage for:

- Redis stream client creation using `BlockingConnectionPool`
- passing `max_connections`, `blocking_pool_timeout`, and `protocol`
- concurrent `write_stream(...)` calls with low `max_connections`
- closing read/write clients cleanly